### PR TITLE
Blend close button into curved edge

### DIFF
--- a/style.css
+++ b/style.css
@@ -141,7 +141,7 @@
 
     .titlebar-button.titlebar-close  {
         border-top-right-radius: var(--blended-addressbar-frame-radius);
-        padding-right: 25px;
+        padding-inline-end: 22px !important;
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -101,7 +101,7 @@
     #nav-bar {
         margin-inline-end: 0 !important;
         padding-inline-start: var(--zen-element-separation) !important;
-        padding-inline-end: var(--zen-element-separation) !important;
+        padding-inline-end: 0 !important;
     }
     #nav-bar,
     #PersonalToolbar {
@@ -137,6 +137,11 @@
     /* Sidebar */
     #sidebar-box {
         border-radius: 0 !important;
+    }
+
+    .titlebar-button.titlebar-close  {
+        border-top-right-radius: var(--blended-addressbar-frame-radius);
+        padding-right: 25px;
     }
 }
 


### PR DESCRIPTION
Blends the titlebar close button into the web panel's curved edge.

**Before:**
<img width="196" height="103" alt="dyn-9c23424f93ee35a156eefe95979a07cc" src="https://github.com/user-attachments/assets/8e3f79b9-4612-4993-999c-fedbda785c40" />

**After:**
<img width="193" height="89" alt="image" src="https://github.com/user-attachments/assets/be3bee26-4b83-401e-ab73-ed1058262573" />
