### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Reworked Progress bar, URL bar glow, and Window edge loadbar styles to share color, opacity, glow intensity, thickness, right-side radius, and width transition behavior.
 - Added a focus-color loadbar preference, set focus color on by default, and changed default loadbar height to `2px` with `80%` opacity.
 - Moved Progress bar to the full window top edge and fixed Window edge placement so it draws on the browser chrome edge instead of tab content.
+- Kept the Window edge loadbar body visible when browser frame padding is disabled.
 - Added a preference to collapse the addressbar/bookmarks separator and kept bookmark folder popups readable with native menu colors.
 - Removed obsolete selector-rule and legacy loadbar color-source handling from the color pipeline.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.4.0 - 2026-06-19
+
+- Made URL bar glow the default custom loadbar style while keeping a Default option for Zen's native loader.
+- Reworked Progress bar, URL bar glow, and Window edge loadbar styles to share color, opacity, glow intensity, thickness, right-side radius, and width transition behavior.
+- Added a focus-color loadbar preference, set focus color on by default, and changed default loadbar height to `2px` with `80%` opacity.
+- Moved Progress bar to the full window top edge and fixed Window edge placement so it draws on the browser chrome edge instead of tab content.
+- Added a preference to collapse the addressbar/bookmarks separator and kept bookmark folder popups readable with native menu colors.
+- Removed obsolete selector-rule and legacy loadbar color-source handling from the color pipeline.
+
 ## 1.3.3 - 2026-06-05
 
 - Removed long-lived persisted site color caching and the `Remember site colors longer` preference so restored tabs do not reuse stale cross-session host colors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Made URL bar glow the default custom loadbar style while keeping a Default option for Zen's native loader.
 - Reworked Progress bar, URL bar glow, and Window edge loadbar styles to share color, opacity, glow intensity, thickness, right-side radius, and width transition behavior.
-- Added a focus-color loadbar preference, set focus color on by default, and changed default loadbar height to `2px` with `80%` opacity.
+- Added a focus-color loadbar preference, set focus color on by default, and changed default loadbar height to `2px` with `100%` opacity.
 - Moved Progress bar to the full window top edge and fixed Window edge placement so it draws on the browser chrome edge instead of tab content.
 - Kept the Window edge loadbar body visible when browser frame padding is disabled.
 - Added a preference to collapse the addressbar/bookmarks separator and kept bookmark folder popups readable with native menu colors.

--- a/MARKETPLACE.md
+++ b/MARKETPLACE.md
@@ -3,7 +3,7 @@
 ## Ready
 
 - Name: `Blended Addressbar` (18 characters).
-- Version: `1.3.3`.
+- Version: `1.4.0`.
 - Description: `A page-aware addressbar that blends Zen chrome with the active website.` (71 characters).
 - Metadata: `theme.json`.
 - Preferences: `preferences.json`.
@@ -29,9 +29,9 @@
   "readme": "https://raw.githubusercontent.com/kkugot/blended-addressbar/main/README.md",
   "image": "https://raw.githubusercontent.com/kkugot/blended-addressbar/main/marketplace-preview.png",
   "author": "Kostiantyn Kugot",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "ai": "partial",
-  "updatedAt": "2026-06-05",
+  "updatedAt": "2026-06-19",
   "style": {
     "chrome": "style.css",
     "content": ""

--- a/README.md
+++ b/README.md
@@ -35,14 +35,15 @@ The mod exposes its settings through `preferences.json`.
 - `uc.blended-addressbar.frame-radius`: outer browser frame corner radius as a CSS length, such as `8px` or `0`.
 - `uc.blended-addressbar.frame-gap`: spacing around the browser frame as a CSS length, such as `5px` or `0`.
 - `uc.blended-addressbar.frame-padding.disabled`: remove the browser frame padding around page content.
-- `uc.blended-addressbar.frame-shadow`: choose the browser frame shadow preset: no shadow, standard, minimal, or medium.
-- `uc.loadbar.mode`: choose Hidden, Progress bar, URL bar glow, or Window edge; Sine's built-in None keeps Zen's default loader.
-- `uc.loadbar.color-source`: choose Zen primary color, page foreground, page background, or a custom color.
-- `uc.loadbar.color`: custom loading bar color.
-- `uc.loadbar.height`: loading bar height.
-- `uc.loadbar.opacity`: loading bar opacity as a percentage.
-- `uc.loadbar.roundedcorner`: enable rounded loading bar corners.
-- `uc.loadbar.shadow`: enable loading bar shadow.
+- `uc.blended-addressbar.addressbar-bookmarks-separator.disabled`: remove the separator between the addressbar and visible bookmarks bar.
+- `uc.blended-addressbar.frame-shadow`: choose the browser frame shadow preset: standard, minimal, or medium.
+- `uc.loadbar.mode`: choose Default, Progress bar, URL bar glow, or Window edge. Default keeps Zen's native loader; the mod defaults to URL bar glow.
+- `uc.loadbar.color`: fallback loadbar color when no page or header color is available.
+- `uc.loadbar.focus-color`: use the browser focus color for Progress bar, URL bar glow, and Window edge instead of the header foreground; enabled by default.
+- `uc.loadbar.height`: loading bar thickness for all custom loadbar styles.
+- `uc.loadbar.opacity`: loading bar body opacity and glow intensity for all custom loadbar styles.
+- `uc.loadbar.roundedcorner`: enable right-side rounded corners for Progress bar, URL bar glow, and Window edge.
+- `uc.loadbar.shadow`: enable shadow for Progress bar and Window edge.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The mod exposes its settings through `preferences.json`.
 - `uc.blended-addressbar.frame-gap`: spacing around the browser frame as a CSS length, such as `5px` or `0`.
 - `uc.blended-addressbar.frame-padding.disabled`: remove the browser frame padding around page content.
 - `uc.blended-addressbar.frame-shadow`: choose the browser frame shadow preset: no shadow, standard, minimal, or medium.
-- `uc.loadbar.position`: choose a full-width left-to-right loading bar or a centered loading bar.
+- `uc.loadbar.mode`: choose Hidden, Progress bar, URL bar glow, or Window edge; Sine's built-in None keeps Zen's default loader.
 - `uc.loadbar.color-source`: choose Zen primary color, page foreground, page background, or a custom color.
 - `uc.loadbar.color`: custom loading bar color.
 - `uc.loadbar.height`: loading bar height.

--- a/blended-bar.uc.js
+++ b/blended-bar.uc.js
@@ -37,6 +37,8 @@
   const loadbarOpacityPref = `${loadbarPrefBranch}opacity`;
   const loadbarColorPref = `${loadbarPrefBranch}color`;
   const loadbarColorSourcePref = `${loadbarPrefBranch}color-source`;
+  const loadbarModePref = `${loadbarPrefBranch}mode`;
+  const loadbarModeValues = Object.freeze(new Set(['hidden', 'progress', 'glow', 'edge']));
   const loadbarColorSourceValues = Object.freeze({
     custom: 'var(--blended-addressbar-loadbar-custom-color)',
     'page-background': 'var(--blended-addressbar-page-loadbar-background, var(--zen-primary-color))',
@@ -1127,6 +1129,8 @@
     const opacity = normalizeOpacity(readStringPref(loadbarOpacityPref, '85'), '0.85');
     const customColor = normalizeCssColor(readStringPref(loadbarColorPref, '#3b82f6'), '#3b82f6');
     const colorSource = readStringPref(loadbarColorSourcePref, 'zen');
+    const mode = readStringPref(loadbarModePref, '');
+    const normalizedMode = loadbarModeValues.has(mode) ? mode : '';
     const colorValue = loadbarColorSourceValues[colorSource] || loadbarColorSourceValues.zen;
 
     setStylePropertyIfChanged(rootStyle, '--blended-addressbar-loadbar-height', height);
@@ -1139,6 +1143,7 @@
       root.setAttribute('data-blended-addressbar-loadbar-opacity', opacity);
       root.setAttribute('data-blended-addressbar-loadbar-color-source', colorSource);
       root.setAttribute('data-blended-addressbar-loadbar-custom-color', customColor);
+      root.setAttribute('data-blended-addressbar-loadbar-mode', normalizedMode);
     }
   }
 

--- a/blended-bar.uc.js
+++ b/blended-bar.uc.js
@@ -1098,7 +1098,7 @@
 
   function getLoadbarGlowMix(opacity, percent) {
     const alpha = Number(opacity);
-    const clamped = Number.isFinite(alpha) ? Math.max(0, Math.min(1, alpha)) : 0.8;
+    const clamped = Number.isFinite(alpha) ? Math.max(0, Math.min(1, alpha)) : 1;
     return `${Math.round(clamped * percent * 1000) / 1000}%`;
   }
 
@@ -1106,7 +1106,7 @@
     const root = chromeDoc.documentElement;
     const rootStyle = root.style;
     const height = normalizeCssLength(readStringPref(loadbarHeightPref, '2px'), '2px');
-    const opacity = normalizeOpacity(readStringPref(loadbarOpacityPref, '80'), '0.8');
+    const opacity = normalizeOpacity(readStringPref(loadbarOpacityPref, '100'), '1');
     const customColor = normalizeCssColor(readStringPref(loadbarColorPref, 'var(--zen-primary-color)'), 'var(--zen-primary-color)');
     const mode = readStringPref(loadbarModePref, defaultLoadbarMode);
     const normalizedMode = normalizeLoadbarMode(mode);

--- a/blended-bar.uc.js
+++ b/blended-bar.uc.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           Blended Addressbar
 // @description    Adaptive header color for Zen URL bar
-// @version        1.3.3
+// @version        1.4.0
 // ==/UserScript==
 
 (() => {
@@ -36,15 +36,9 @@
   const loadbarHeightPref = `${loadbarPrefBranch}height`;
   const loadbarOpacityPref = `${loadbarPrefBranch}opacity`;
   const loadbarColorPref = `${loadbarPrefBranch}color`;
-  const loadbarColorSourcePref = `${loadbarPrefBranch}color-source`;
   const loadbarModePref = `${loadbarPrefBranch}mode`;
-  const loadbarModeValues = Object.freeze(new Set(['hidden', 'progress', 'glow', 'edge']));
-  const loadbarColorSourceValues = Object.freeze({
-    custom: 'var(--blended-addressbar-loadbar-custom-color)',
-    'page-background': 'var(--blended-addressbar-page-loadbar-background, var(--zen-primary-color))',
-    'page-foreground': 'var(--blended-addressbar-page-loadbar-foreground, var(--zen-primary-color))',
-    zen: 'var(--zen-primary-color)'
-  });
+  const loadbarFocusColorPref = `${loadbarPrefBranch}focus-color`;
+  const defaultLoadbarMode = 'glow';
   const addressbarPrefBranch = 'uc.blended-addressbar.';
   const frameRadiusPref = `${addressbarPrefBranch}frame-radius`;
   const frameGapPref = `${addressbarPrefBranch}frame-gap`;
@@ -58,8 +52,6 @@
   ]));
   const windowTintEnabledPref = `${addressbarPrefBranch}window-tint.enabled`;
   const windowTintStrengthPref = `${addressbarPrefBranch}window-tint.strength`;
-  const legacySidebarEnabledPref = `${addressbarPrefBranch}sidebar.enabled`;
-  const selectorRulePref = `${addressbarPrefBranch}selector-rule`;
   const defaultWindowTintStrengthPercent = 25;
   const nativeZenThemeProperties = [
     '--zen-main-browser-background',
@@ -171,19 +163,16 @@
   } = loadBlendedAddressbarModule('theme-source-policy.js');
 
   const {
-    clearUserPref,
     cssSupports,
     getPrefs,
     normalizeCssColor,
     normalizeCssLength,
     normalizeFrameShadowPreset,
+    normalizeLoadbarMode,
     normalizeOpacity,
     normalizePercent,
-    prefHasUserValue,
     readBoolPref,
-    readIntPref,
-    readStringPref,
-    writeStringPref
+    readStringPref
   } = loadBlendedAddressbarModule('prefs.js', {
     getServices,
     window
@@ -1001,21 +990,7 @@
   }
 
   function readWindowTintEnabled() {
-    if (prefHasUserValue(windowTintEnabledPref)) {
-      return readBoolPref(windowTintEnabledPref, false);
-    }
-
-    return readBoolPref(legacySidebarEnabledPref, false);
-  }
-
-  function migrateWindowTintPref() {
-    const prefs = getPrefs();
-    if (!prefs?.setBoolPref) return;
-    if (prefHasUserValue(windowTintEnabledPref) || !prefHasUserValue(legacySidebarEnabledPref)) return;
-
-    try {
-      prefs.setBoolPref(windowTintEnabledPref, readBoolPref(legacySidebarEnabledPref, false));
-    } catch {}
+    return readBoolPref(windowTintEnabledPref, false);
   }
 
   function readWindowTintStrengthPercent() {
@@ -1093,8 +1068,7 @@
         const changedPref = String(prefName || '');
         if (topic !== 'nsPref:changed'
           || (changedPref !== windowTintEnabledPref
-            && changedPref !== windowTintStrengthPref
-            && changedPref !== legacySidebarEnabledPref)) {
+            && changedPref !== windowTintStrengthPref)) {
           return;
         }
 
@@ -1122,28 +1096,36 @@
     } catch {}
   }
 
+  function getLoadbarGlowMix(opacity, percent) {
+    const alpha = Number(opacity);
+    const clamped = Number.isFinite(alpha) ? Math.max(0, Math.min(1, alpha)) : 0.8;
+    return `${Math.round(clamped * percent * 1000) / 1000}%`;
+  }
+
   function applyLoadbarPrefs() {
     const root = chromeDoc.documentElement;
     const rootStyle = root.style;
     const height = normalizeCssLength(readStringPref(loadbarHeightPref, '2px'), '2px');
-    const opacity = normalizeOpacity(readStringPref(loadbarOpacityPref, '85'), '0.85');
-    const customColor = normalizeCssColor(readStringPref(loadbarColorPref, '#3b82f6'), '#3b82f6');
-    const colorSource = readStringPref(loadbarColorSourcePref, 'zen');
-    const mode = readStringPref(loadbarModePref, '');
-    const normalizedMode = loadbarModeValues.has(mode) ? mode : '';
-    const colorValue = loadbarColorSourceValues[colorSource] || loadbarColorSourceValues.zen;
+    const opacity = normalizeOpacity(readStringPref(loadbarOpacityPref, '80'), '0.8');
+    const customColor = normalizeCssColor(readStringPref(loadbarColorPref, 'var(--zen-primary-color)'), 'var(--zen-primary-color)');
+    const mode = readStringPref(loadbarModePref, defaultLoadbarMode);
+    const normalizedMode = normalizeLoadbarMode(mode);
+    const useFocusColor = readBoolPref(loadbarFocusColorPref, true);
 
     setStylePropertyIfChanged(rootStyle, '--blended-addressbar-loadbar-height', height);
     setStylePropertyIfChanged(rootStyle, '--blended-addressbar-loadbar-opacity', opacity);
-    setStylePropertyIfChanged(rootStyle, '--blended-addressbar-loadbar-custom-color', customColor);
-    setStylePropertyIfChanged(rootStyle, '--blended-addressbar-loadbar-color', colorValue);
+    setStylePropertyIfChanged(rootStyle, '--blended-addressbar-loadbar-static-color', customColor);
+    setStylePropertyIfChanged(rootStyle, '--blended-addressbar-loadbar-glow-strong-mix', getLoadbarGlowMix(opacity, 34));
+    setStylePropertyIfChanged(rootStyle, '--blended-addressbar-loadbar-glow-medium-mix', getLoadbarGlowMix(opacity, 18));
+    setStylePropertyIfChanged(rootStyle, '--blended-addressbar-loadbar-glow-weak-mix', getLoadbarGlowMix(opacity, 7));
+    root.setAttribute('data-blended-addressbar-loadbar-mode', normalizedMode);
+    root.setAttribute('data-blended-addressbar-loadbar-focus-color', String(useFocusColor));
 
     if (DEBUG_THEME) {
       root.setAttribute('data-blended-addressbar-loadbar-height', height);
       root.setAttribute('data-blended-addressbar-loadbar-opacity', opacity);
-      root.setAttribute('data-blended-addressbar-loadbar-color-source', colorSource);
       root.setAttribute('data-blended-addressbar-loadbar-custom-color', customColor);
-      root.setAttribute('data-blended-addressbar-loadbar-mode', normalizedMode);
+      root.setAttribute('data-blended-addressbar-loadbar-focus-color-enabled', String(useFocusColor));
     }
   }
 
@@ -1439,78 +1421,6 @@
     return null;
   }
 
-  function parseSelectorRule(value) {
-    const raw = String(value || '').trim();
-    if (!raw) return null;
-
-    try {
-      const rule = JSON.parse(raw);
-      if (!rule || typeof rule !== 'object' || Array.isArray(rule)) return null;
-
-      const url = String(rule.url || '').trim();
-      const bg = String(rule.bg || '').trim();
-      const fg = String(rule.fg || '').trim();
-      return url && bg ? { url, bg, fg } : null;
-    } catch {
-      return null;
-    }
-  }
-
-  function wildcardMatches(pattern, value) {
-    const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
-    return new RegExp(`^${escaped}$`).test(value);
-  }
-
-  function selectorRuleMatchesUrl(pattern, href) {
-    const ruleUrl = String(pattern || '').trim();
-    if (!ruleUrl || !href) return false;
-    if (ruleUrl.includes('*')) return wildcardMatches(ruleUrl, href);
-
-    try {
-      if (ruleUrl.includes('://')) return href.startsWith(ruleUrl);
-      return new URL(href).hostname === ruleUrl;
-    } catch {
-      return href.startsWith(ruleUrl);
-    }
-  }
-
-  function getSelectorRuleElement(view, doc, selector) {
-    const raw = String(selector || '').trim();
-    if (!raw) return null;
-
-    try {
-      return getFirstRenderedElement(view, doc, raw);
-    } catch {
-      return null;
-    }
-  }
-
-  function getSelectorRuleTheme(doc, view, href, value) {
-    if (!doc || !view) return null;
-
-    const rule = parseSelectorRule(value);
-    if (!rule || !selectorRuleMatchesUrl(rule.url, href || doc.location?.href || '')) return null;
-
-    const bgElement = getSelectorRuleElement(view, doc, rule.bg);
-    const bgTheme = getThemeFromElement(view, bgElement, 'selector-rule', false);
-    if (!bgTheme?.bg) return null;
-
-    const foregroundCandidates = [];
-    const fgElement = getSelectorRuleElement(view, doc, rule.fg);
-    if (fgElement) {
-      foregroundCandidates.push(...collectForegroundCandidates(view, fgElement, false));
-    }
-    foregroundCandidates.push(...collectForegroundCandidates(view, bgElement, false));
-    foregroundCandidates.push(bgTheme.fg);
-
-    return {
-      bg: bgTheme.bg,
-      fg: getReadableForeground(bgTheme.bg, foregroundCandidates),
-      source: 'selector-rule',
-      selectorRule: rule
-    };
-  }
-
   function getTopVisibleTheme(doc, view) {
     if (!doc || !view) return null;
 
@@ -1581,9 +1491,7 @@
         candidates
       });
 
-      const selectorRuleValue = readStringPref(selectorRulePref, '');
-      return withMeta(getSelectorRuleTheme(doc, view, href, selectorRuleValue))
-        || withMeta(getDarkReaderTheme(doc, view))
+      return withMeta(getDarkReaderTheme(doc, view))
         || withMeta(getTopVisibleTheme(doc, view))
         || withMeta(getThemeColorTheme(doc, view))
         || withMeta(getThemeFromElement(view, doc.body, 'body'))
@@ -1686,7 +1594,6 @@
       (() => {
         const requestId = ${JSON.stringify(requestId)};
         const messageName = ${JSON.stringify(themeMessageName)};
-        const selectorRuleValue = ${JSON.stringify(readStringPref(selectorRulePref, ''))};
 
         const send = (payload) => {
           sendAsyncMessage(messageName, { requestId, ...payload });
@@ -2092,78 +1999,6 @@
           return null;
         };
 
-        const parseSelectorRule = (value) => {
-          const raw = String(value || '').trim();
-          if (!raw) return null;
-
-          try {
-            const rule = JSON.parse(raw);
-            if (!rule || typeof rule !== 'object' || Array.isArray(rule)) return null;
-
-            const url = String(rule.url || '').trim();
-            const bg = String(rule.bg || '').trim();
-            const fg = String(rule.fg || '').trim();
-            return url && bg ? { url, bg, fg } : null;
-          } catch {
-            return null;
-          }
-        };
-
-        const wildcardMatches = (pattern, value) => {
-          const escaped = pattern.replace(/[|\\{}()[\\]^$+*?.]/g, '\\$&').replace(/\\\*/g, '.*');
-          return new RegExp('^' + escaped + '$').test(value);
-        };
-
-        const selectorRuleMatchesUrl = (pattern, href) => {
-          const ruleUrl = String(pattern || '').trim();
-          if (!ruleUrl || !href) return false;
-          if (ruleUrl.includes('*')) return wildcardMatches(ruleUrl, href);
-
-          try {
-            if (ruleUrl.includes('://')) return href.startsWith(ruleUrl);
-            return new URL(href).hostname === ruleUrl;
-          } catch {
-            return href.startsWith(ruleUrl);
-          }
-        };
-
-        const getSelectorRuleElement = (view, doc, selector) => {
-          const raw = String(selector || '').trim();
-          if (!raw) return null;
-
-          try {
-            return getFirstRenderedElement(view, doc, raw);
-          } catch {
-            return null;
-          }
-        };
-
-        const getSelectorRuleTheme = (doc, view, href, value) => {
-          if (!doc || !view) return null;
-
-          const rule = parseSelectorRule(value);
-          if (!rule || !selectorRuleMatchesUrl(rule.url, href || doc.location?.href || '')) return null;
-
-          const bgElement = getSelectorRuleElement(view, doc, rule.bg);
-          const bgTheme = getThemeFromElement(view, bgElement, 'selector-rule', false);
-          if (!bgTheme?.bg) return null;
-
-          const foregroundCandidates = [];
-          const fgElement = getSelectorRuleElement(view, doc, rule.fg);
-          if (fgElement) {
-            foregroundCandidates.push(...collectForegroundCandidates(view, fgElement, false));
-          }
-          foregroundCandidates.push(...collectForegroundCandidates(view, bgElement, false));
-          foregroundCandidates.push(bgTheme.fg);
-
-          return {
-            bg: bgTheme.bg,
-            fg: getReadableForeground(bgTheme.bg, foregroundCandidates),
-            source: 'selector-rule',
-            selectorRule: rule
-          };
-        };
-
         const getTopVisibleTheme = (doc, view) => {
           if (!doc || !view) return null;
 
@@ -2235,8 +2070,7 @@
           };
 
           const href = content.location.href;
-          const theme = withMeta(getSelectorRuleTheme(doc, view, href, selectorRuleValue), href, candidates)
-            || withMeta(getDarkReaderTheme(doc, view), href, candidates)
+          const theme = withMeta(getDarkReaderTheme(doc, view), href, candidates)
             || withMeta(getTopVisibleTheme(doc, view), href, candidates)
             || withMeta(getThemeColorTheme(doc, view), href, candidates)
             || withMeta(getThemeFromElement(view, doc.body, 'body'), href, candidates)
@@ -2328,10 +2162,8 @@
       return null;
     }
 
-    const selectorRuleValue = readStringPref(selectorRulePref, '');
-
     try {
-      return await ContentTask.spawn(browser, selectorRuleValue, (selectorRuleValue) => {
+      return await ContentTask.spawn(browser, null, () => {
         const describeElementTheme = (view, element) => {
           if (!view || !element) {
             return { found: false, bg: null, fg: null };
@@ -2732,78 +2564,6 @@
           return null;
         };
 
-        const parseSelectorRule = (value) => {
-          const raw = String(value || '').trim();
-          if (!raw) return null;
-
-          try {
-            const rule = JSON.parse(raw);
-            if (!rule || typeof rule !== 'object' || Array.isArray(rule)) return null;
-
-            const url = String(rule.url || '').trim();
-            const bg = String(rule.bg || '').trim();
-            const fg = String(rule.fg || '').trim();
-            return url && bg ? { url, bg, fg } : null;
-          } catch {
-            return null;
-          }
-        };
-
-        const wildcardMatches = (pattern, value) => {
-          const escaped = pattern.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/\\\*/g, '.*');
-          return new RegExp('^' + escaped + '$').test(value);
-        };
-
-        const selectorRuleMatchesUrl = (pattern, href) => {
-          const ruleUrl = String(pattern || '').trim();
-          if (!ruleUrl || !href) return false;
-          if (ruleUrl.includes('*')) return wildcardMatches(ruleUrl, href);
-
-          try {
-            if (ruleUrl.includes('://')) return href.startsWith(ruleUrl);
-            return new URL(href).hostname === ruleUrl;
-          } catch {
-            return href.startsWith(ruleUrl);
-          }
-        };
-
-        const getSelectorRuleElement = (view, doc, selector) => {
-          const raw = String(selector || '').trim();
-          if (!raw) return null;
-
-          try {
-            return getFirstRenderedElement(view, doc, raw);
-          } catch {
-            return null;
-          }
-        };
-
-        const getSelectorRuleTheme = (doc, view, href, value) => {
-          if (!doc || !view) return null;
-
-          const rule = parseSelectorRule(value);
-          if (!rule || !selectorRuleMatchesUrl(rule.url, href || doc.location?.href || '')) return null;
-
-          const bgElement = getSelectorRuleElement(view, doc, rule.bg);
-          const bgTheme = getThemeFromElement(view, bgElement, 'selector-rule', false);
-          if (!bgTheme?.bg) return null;
-
-          const foregroundCandidates = [];
-          const fgElement = getSelectorRuleElement(view, doc, rule.fg);
-          if (fgElement) {
-            foregroundCandidates.push(...collectForegroundCandidates(view, fgElement, false));
-          }
-          foregroundCandidates.push(...collectForegroundCandidates(view, bgElement, false));
-          foregroundCandidates.push(bgTheme.fg);
-
-          return {
-            bg: bgTheme.bg,
-            fg: getReadableForeground(bgTheme.bg, foregroundCandidates),
-            source: 'selector-rule',
-            selectorRule: rule
-          };
-        };
-
         const getTopVisibleTheme = (doc, view) => {
           if (!doc || !view) return null;
 
@@ -2870,8 +2630,7 @@
           };
 
           const href = content.location.href;
-          return withMeta(getSelectorRuleTheme(doc, view, href, selectorRuleValue), href, candidates)
-            || withMeta(getDarkReaderTheme(doc, view), href, candidates)
+          return withMeta(getDarkReaderTheme(doc, view), href, candidates)
             || withMeta(getTopVisibleTheme(doc, view), href, candidates)
             || withMeta(getThemeColorTheme(doc, view), href, candidates)
             || withMeta(getThemeFromElement(view, doc.body, 'body'), href, candidates)
@@ -3479,7 +3238,6 @@
     }
 
     applyFramePrefs();
-    migrateWindowTintPref();
     observeFramePrefs();
     applyLoadbarPrefs();
     observeLoadbarPrefs();

--- a/docs/color-architecture.md
+++ b/docs/color-architecture.md
@@ -10,12 +10,11 @@ This document describes the current adaptive color pipeline for Blended Addressb
 - `scripts/prefs.js` owns preference access and preference value normalization.
 - `scripts/pane-layout.js` owns split-pane/browser-frame corner radius observation and updates.
 - `scripts/theme-source-policy.js` owns color source policy metadata, confidence lookup, preferred semantic checks, and rendered-source checks.
-- `scripts/site-theme-cache.js` owns host-cache preference serialization and deserialization, including compact bounded persistence.
 - `frame.js` runs in page content through a persistent frame listener. It watches page theme mutations, load, and pageshow events, then sends lightweight color samples back to chrome. Scroll does not trigger color updates.
 - `style.css` consumes chrome CSS variables such as `--zen-tab-header-background`, `--zen-tab-header-foreground`, `--blended-addressbar-frame-background`, and `--blended-addressbar-window-tint-background`.
 - `styles/header-chrome.css` consumes the header foreground variables for hidden-tabs and compact-mode chrome icon styling.
 - `styles/loadbar.css` consumes loadbar variables and preferences.
-- `preferences.json` exposes user settings. Exact tab and page colors are remembered in memory. Host-level fallback caching, including persistence across restarts, is enabled only while `uc.blended-addressbar.remember-site-colors-longer` is true.
+- `preferences.json` exposes user settings. Exact tab and page colors are remembered in memory while browsing.
 
 ## Current Event Flow
 
@@ -94,7 +93,6 @@ Source metadata is centralized in `scripts/theme-source-policy.js`; ordering dec
 
 | Source | Class | Rendered/trusted? | Confidence | Notes |
 | --- | --- | --- | --- | --- |
-| `selector-rule` | explicit semantic | yes, but not pixel-derived | 7 | User-defined selector override. Treated as trusted during normal browsing, but ignored while Boost requires actual pixels. |
 | `theme-color` | preferred semantic | no | 7 | Preferred during normal active loads so semantic site color can stay stable. Ignored while Boost requires pixel-derived sources. |
 | `top-visible` | visual DOM | yes, but not pixel-derived | 6 | Top visible element from chrome-side DOM read or persistent-frame ancestor sampling. Ignored while Boost requires actual pixels. |
 | `pixel-top-edge` / `pixel` | visual pixel | yes | 6 | Persistent content or chrome snapshot of rendered top edge. |
@@ -109,8 +107,6 @@ Source metadata is centralized in `scripts/theme-source-policy.js`; ordering dec
 
 - `themeCache`: per-browser `WeakMap` for the current exact tab and href.
 - `pageThemeCache`: bounded in-memory cache by origin and pathname. This is the preferred tab-switch fallback after exact tab cache.
-- `hostThemeCache`: host-level fallback. The in-memory map is capped separately from persistence and can persist across restarts when `remember-site-colors-longer` is enabled.
-- `site-theme-cache` preference payload: compact versioned JSON written by `scripts/site-theme-cache.js`. Persistence keeps only the newest bounded host entries, omits hrefs entirely, and clears the preference if no serialized payload fits the byte budget.
 - Same-host retention: if the next tab has the same host as the last applied theme, the previous theme can be retained briefly instead of flashing neutral while an unloaded tab restores.
 
 Cache precedence on tab switch is:
@@ -159,7 +155,6 @@ The first refactor phase is implemented across `blended-bar.uc.js` and the helpe
 - Cached tab switches can now return after successfully painting the cached/retained color, avoiding an immediate persistent-frame sample on switch while still continuing if the cached candidate is rejected.
 - Navigation no longer runs a repeating loading poll loop; active loads use one coalesced early update, one settled update, and persistent-frame `load`/`pageshow` refreshes.
 - Repeated CSS property writes use `scripts/style-state.js` so equivalent values are no-ops.
-- Host-cache preference serialization now lives in `scripts/site-theme-cache.js` and writes compact bounded payloads.
 - Hidden-tabs chrome foreground styling now lives in `styles/header-chrome.css`, imported by `style.css`.
 
 The larger pipeline split below is still proposed.
@@ -199,7 +194,7 @@ The resolver can then be a small policy matrix instead of scattered booleans:
 | --- | --- |
 | Tab switch with exact cache | Paint exact tab/page cache immediately and do not force a fresh sample in the same switch turn. |
 | Tab switch same host, no exact cache | Retain previous same-host visual color and do not force a fresh sample in the same switch turn. |
-| Loading, no cache | Prefer `selector-rule`, `theme-color`, `dark-reader`, or rendered visual source. Avoid neutral unless no useful candidate exists. |
+| Loading, no cache | Prefer `theme-color`, `dark-reader`, or rendered visual source. Avoid neutral unless no useful candidate exists. |
 | Loading with weak semantic source | Defer or ignore `body`, `html`, and `document-canvas` until stable. |
 | Boost active | Rendered-only mode: accept visual pixel/top-visible/Dark Reader/rendered cache; reject non-rendered semantic and broad host fallbacks. |
 | Settled page | Allow semantic preferred sources and rendered sources, but use hysteresis so small or lower-confidence changes do not disturb the UI. |

--- a/preferences.json
+++ b/preferences.json
@@ -114,7 +114,7 @@
     "property": "uc.loadbar.opacity",
     "label": "Opacity (%)",
     "type": "string",
-    "defaultValue": "80"
+    "defaultValue": "100"
   },
   {
     "property": "uc.loadbar.roundedcorner",

--- a/preferences.json
+++ b/preferences.json
@@ -22,15 +22,16 @@
     "type": "checkbox"
   },
   {
+    "property": "uc.blended-addressbar.addressbar-bookmarks-separator.disabled",
+    "label": "Remove addressbar/bookmarks separator",
+    "type": "checkbox"
+  },
+  {
     "property": "uc.blended-addressbar.frame-shadow",
     "label": "Frame shadow",
     "type": "dropdown",
     "defaultValue": "standard",
     "options": [
-      {
-        "label": "No shadow",
-        "value": "none"
-      },
       {
         "label": "Standard",
         "value": "standard"
@@ -71,10 +72,11 @@
     "property": "uc.loadbar.mode",
     "label": "Loading indicator",
     "type": "dropdown",
+    "defaultValue": "glow",
     "options": [
       {
-        "label": "Hidden",
-        "value": "hidden"
+        "label": "Default",
+        "value": "default"
       },
       {
         "label": "Progress bar",
@@ -91,35 +93,16 @@
     ]
   },
   {
-    "property": "uc.loadbar.color-source",
-    "label": "Color source",
-    "type": "dropdown",
-    "placeholder": "Zen Primary",
-    "defaultValue": "zen",
-    "options": [
-      {
-        "label": "Zen Primary",
-        "value": "zen"
-      },
-      {
-        "label": "Page Foreground",
-        "value": "page-foreground"
-      },
-      {
-        "label": "Page Background",
-        "value": "page-background"
-      },
-      {
-        "label": "Custom Color",
-        "value": "custom"
-      }
-    ]
+    "property": "uc.loadbar.color",
+    "label": "Fallback loadbar color",
+    "type": "string",
+    "defaultValue": "var(--zen-primary-color)"
   },
   {
-    "property": "uc.loadbar.color",
-    "label": "Custom color",
-    "type": "string",
-    "defaultValue": "#3b82f6"
+    "property": "uc.loadbar.focus-color",
+    "label": "Use focus color",
+    "type": "checkbox",
+    "defaultValue": true
   },
   {
     "property": "uc.loadbar.height",
@@ -131,7 +114,7 @@
     "property": "uc.loadbar.opacity",
     "label": "Opacity (%)",
     "type": "string",
-    "defaultValue": "85"
+    "defaultValue": "80"
   },
   {
     "property": "uc.loadbar.roundedcorner",

--- a/preferences.json
+++ b/preferences.json
@@ -68,18 +68,25 @@
     "margin": "20px 0 12px 0"
   },
   {
-    "property": "uc.loadbar.position",
-    "label": "Loading bar layout",
+    "property": "uc.loadbar.mode",
+    "label": "Loading indicator",
     "type": "dropdown",
-    "defaultValue": "full",
     "options": [
       {
-        "label": "Full width",
-        "value": "full"
+        "label": "Hidden",
+        "value": "hidden"
       },
       {
-        "label": "Centered",
-        "value": "center"
+        "label": "Progress bar",
+        "value": "progress"
+      },
+      {
+        "label": "URL bar glow",
+        "value": "glow"
+      },
+      {
+        "label": "Window edge",
+        "value": "edge"
       }
     ]
   },

--- a/scripts/prefs.js
+++ b/scripts/prefs.js
@@ -2,6 +2,8 @@ var BlendedAddressbarModule = ((options) => {
   'use strict';
 
   options = options || {};
+  const loadbarModeFallback = 'glow';
+  const loadbarModeValues = Object.freeze(new Set(['default', 'progress', 'glow', 'edge']));
   const getServices = typeof options.getServices === 'function'
     ? options.getServices
     : (() => null);
@@ -30,63 +32,12 @@ var BlendedAddressbarModule = ((options) => {
     return fallback;
   }
 
-  function writeStringPref(name, value) {
-    const prefs = getPrefs();
-    if (!prefs) return false;
-
-    try {
-      prefs.setStringPref(name, value);
-      return true;
-    } catch {}
-
-    try {
-      prefs.setCharPref(name, value);
-      return true;
-    } catch {}
-
-    return false;
-  }
-
-  function clearUserPref(name) {
-    const prefs = getPrefs();
-    if (!prefs?.clearUserPref) return false;
-
-    try {
-      prefs.clearUserPref(name);
-      return true;
-    } catch {}
-
-    return false;
-  }
-
   function readBoolPref(name, fallback) {
     const prefs = getPrefs();
     if (!prefs) return fallback;
 
     try {
       return prefs.getBoolPref(name, fallback);
-    } catch {}
-
-    return fallback;
-  }
-
-  function prefHasUserValue(name) {
-    const prefs = getPrefs();
-    if (!prefs?.prefHasUserValue) return false;
-
-    try {
-      return prefs.prefHasUserValue(name);
-    } catch {}
-
-    return false;
-  }
-
-  function readIntPref(name, fallback) {
-    const prefs = getPrefs();
-    if (!prefs) return fallback;
-
-    try {
-      return prefs.getIntPref(name, fallback);
     } catch {}
 
     return fallback;
@@ -110,7 +61,13 @@ var BlendedAddressbarModule = ((options) => {
 
   function normalizeFrameShadowPreset(value) {
     const preset = String(value || '').trim();
-    return ['standard', 'minimal', 'medium', 'none'].includes(preset) ? preset : 'standard';
+    return ['standard', 'minimal', 'medium'].includes(preset) ? preset : 'standard';
+  }
+
+  function normalizeLoadbarMode(value) {
+    const mode = String(value || '').trim();
+    if (mode === 'none') return 'default';
+    return loadbarModeValues.has(mode) ? mode : loadbarModeFallback;
   }
 
   function normalizeCssColor(value, fallback) {
@@ -150,18 +107,15 @@ var BlendedAddressbarModule = ((options) => {
   }
 
   return Object.freeze({
-    clearUserPref,
     cssSupports,
     getPrefs,
     normalizeCssColor,
     normalizeCssLength,
     normalizeFrameShadowPreset,
+    normalizeLoadbarMode,
     normalizeOpacity,
     normalizePercent,
-    prefHasUserValue,
     readBoolPref,
-    readIntPref,
-    readStringPref,
-    writeStringPref
+    readStringPref
   });
 })(BlendedAddressbarModuleOptions);

--- a/scripts/theme-source-policy.js
+++ b/scripts/theme-source-policy.js
@@ -2,7 +2,6 @@ var BlendedAddressbarModule = (() => {
   'use strict';
 
   const colorSourcePolicies = Object.freeze({
-    'selector-rule': Object.freeze({ sourceClass: 'explicit', rendered: true, confidence: 7, preferred: true }),
     'dark-reader': Object.freeze({ sourceClass: 'visual', rendered: true, confidence: 5, modifier: true }),
     'top-visible': Object.freeze({ sourceClass: 'visual', rendered: true, confidence: 6 }),
     'pixel-top-edge': Object.freeze({ sourceClass: 'visual', rendered: true, confidence: 6 }),

--- a/style.css
+++ b/style.css
@@ -16,6 +16,9 @@
         0 5px 12px rgba(0, 0, 0, 0.10),
         0 1px 2px rgba(0, 0, 0, 0.10);
     --blended-addressbar-frame-shadow: var(--blended-addressbar-frame-shadow-standard);
+    --blended-addressbar-toolbar-separator-shadow: 0 -1px 0 0 inset rgba(128, 128, 128, 0.09);
+    --blended-addressbar-bookmark-popup-radius: 8px;
+    --blended-addressbar-bookmark-popup-border-color: color-mix(in srgb, MenuText 18%, transparent);
 }
 
 :root[data-blended-addressbar-frame-shadow="minimal"] {
@@ -24,10 +27,6 @@
 
 :root[data-blended-addressbar-frame-shadow="medium"] {
     --blended-addressbar-frame-shadow: var(--blended-addressbar-frame-shadow-medium);
-}
-
-:root[data-blended-addressbar-frame-shadow="none"] {
-    --blended-addressbar-frame-shadow: none;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -172,6 +171,47 @@
             --toolbarbutton-icon-fill: currentColor;
         }
 
+        #PersonalToolbar toolbarbutton.bookmark-item > menupopup.toolbar-menupopup[placespopup="true"] {
+            --panel-background: Menu !important;
+            --panel-color: MenuText !important;
+            --panel-border-color: var(--blended-addressbar-bookmark-popup-border-color) !important;
+            --panel-border-radius: var(--blended-addressbar-bookmark-popup-radius) !important;
+            --arrowpanel-background: Menu !important;
+            --arrowpanel-color: MenuText !important;
+            --arrowpanel-border-color: var(--blended-addressbar-bookmark-popup-border-color) !important;
+            --arrowpanel-border-radius: var(--blended-addressbar-bookmark-popup-radius) !important;
+            color: MenuText !important;
+            fill: currentColor !important;
+            stroke: currentColor !important;
+            --toolbox-textcolor: MenuText;
+            --toolbarbutton-icon-fill: currentColor;
+            --toolbar-color: MenuText;
+        }
+
+        #PersonalToolbar toolbarbutton.bookmark-item > menupopup.toolbar-menupopup[placespopup="true"]::part(content) {
+            background: Menu !important;
+            color: MenuText !important;
+            border-color: var(--blended-addressbar-bookmark-popup-border-color) !important;
+            border-radius: var(--blended-addressbar-bookmark-popup-radius) !important;
+            overflow: hidden !important;
+        }
+
+        #PersonalToolbar toolbarbutton.bookmark-item > menupopup.toolbar-menupopup[placespopup="true"] :is(menu, menuitem, .menu-iconic, .menuitem-iconic, .bookmark-item) {
+            color: MenuText !important;
+            fill: currentColor !important;
+            stroke: currentColor !important;
+            --toolbox-textcolor: MenuText;
+            --toolbarbutton-icon-fill: currentColor;
+            --toolbar-color: MenuText;
+        }
+
+        #PersonalToolbar toolbarbutton.bookmark-item > menupopup.toolbar-menupopup[placespopup="true"] :is(menu, menuitem, .bookmark-item):is([disabled], [disabled="true"]) {
+            color: GrayText !important;
+            fill: currentColor !important;
+            stroke: currentColor !important;
+            --toolbarbutton-icon-fill: currentColor;
+        }
+
         #urlbar:not([zen-floating-urlbar="true"]) {
             color: var(--zen-tab-header-foreground, inherit);
             transition: color var(--blended-addressbar-color-transition);
@@ -210,10 +250,17 @@
         margin-inline-end: 0 !important;
         padding-inline-start: var(--zen-element-separation) !important;
         padding-inline-end: 0 !important;
+        box-shadow: var(--blended-addressbar-toolbar-separator-shadow);
     }
-    #nav-bar,
-    #PersonalToolbar {
-        box-shadow: 0 -1px 0 0 inset rgba(128,128,128, 0.09);
+
+    #nav-bar:not([hidden]):not([collapsed="true"]) + #PersonalToolbar:not([hidden]):not([collapsed="true"]) {
+        box-shadow: var(--blended-addressbar-toolbar-separator-shadow);
+    }
+
+    @media (-moz-bool-pref: "uc.blended-addressbar.addressbar-bookmarks-separator.disabled") {
+        #nav-bar:not([hidden]):not([collapsed="true"]):has(+ #PersonalToolbar:not([hidden]):not([collapsed="true"])) {
+            box-shadow: none !important;
+        }
     }
 
     /* The webpage content wrapper */

--- a/styles/loadbar.css
+++ b/styles/loadbar.css
@@ -1,110 +1,252 @@
-
 /* Loader bar */
 
 @-moz-document url-prefix("chrome:") {
-  /* Assume single-toolbar mode as the base use case */
-  .browserSidebarContainer.deck-selected::before {
-    content: "" !important;
-    position: absolute !important;
-    top: 0px !important; /* This will get overridden if the toolbar is showing */
-    left: 0px !important;
-    transform: none !important;
-    height: var(--blended-addressbar-loadbar-height, 2px) !important; /* Height of the top background */
-    max-width: 100% !important;
-    width: var(--bar-pcent) !important; /* Ensure full width or customizable width */
-    background-color: var(--bar-colour, var(--blended-addressbar-loadbar-color, var(--zen-primary-color))) !important; /* Solid color for the bar */
-    opacity: var(--blended-addressbar-loadbar-opacity, 0.85) !important;
-    @media (-moz-bool-pref: "uc.loadbar.shadow") {
-      filter: drop-shadow(0px 0px 10px black) !important;
+  @keyframes blended-addressbar-loadbar-glow-sweep {
+    from {
+      background-position: -6rem 0, 0 0;
     }
-    border-radius: 0 var(--blended-addressbar-loadbar-height, 2px) var(--blended-addressbar-loadbar-height, 2px) 0 !important;
-    @media not (-moz-bool-pref: "uc.loadbar.roundedcorner") {
-       border-radius: 0 !important; /* Adjust this value to control the roundness of the ends */
+
+    to {
+      background-position: calc(100% + 6rem) 0, 0 0;
     }
-    z-index: 1 !important;
-    /* Apply smooth transition on width, top, opacity and background */
-    transition: width 0.5s ease-in-out, top 0.1s ease-in-out, left 0.2s ease-in-out, transform 0.2s ease-in-out, opacity 0.2s ease-in-out, background 0.2s ease !important;
   }
 
-  /* When the toolbar is permanently showing, we move the loading bar under it */
-  @media not (-moz-bool-pref: "zen.view.compact.hide-toolbar") and not (-moz-bool-pref: "zen.view.use-single-toolbar") {
-    .browserSidebarContainer.deck-selected::before {
-      top: 39px !important;
-    }
-  }
-  
-  .browserSidebarContainer.deck-selected:has([zen-glance-selected])::before,
-  .browserSidebarContainer.deck-selected.zen-glance-overlay::before {
-    max-width: calc(85%) !important;
-    left: calc(15%/2) !important;
-    border-radius: 6px !important;
-  }
-
-  @media (-moz-pref("uc.loadbar.position", "center")) {
-    .browserSidebarContainer.deck-selected::before,
-    .browserSidebarContainer.deck-selected:has([zen-glance-selected])::before,
-    .browserSidebarContainer.deck-selected.zen-glance-overlay::before {
-      left: 50% !important;
-      transform: translateX(-50%) !important;
-      width: var(--bar-pcent) !important;
-    }
-  }
-  
-  .browserSidebarContainer.deck-selected.zen-glance-background::before {
-    background: transparent !important;
-    height: 0px !important;
-  }
-  
   :root {
-    &:has(.tabbrowser-tab[selected][busy]) {
-      --bar-colour: var(--blended-addressbar-loadbar-color, var(--zen-primary-color));
-      --bar-pcent: 15%;
+    --blended-addressbar-loadbar-progress: 0%;
+    --blended-addressbar-loadbar-track-color: color-mix(in srgb, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)) 16%, transparent);
+    --blended-addressbar-loadbar-glow-color: color-mix(in srgb, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)) 46%, transparent);
+  }
+
+  :root:has(#zen-loading-progress-bar[long-load="false"]) {
+    --blended-addressbar-loadbar-progress: 45%;
+  }
+
+  :root:has(#zen-loading-progress-bar[long-load="true"]) {
+    --blended-addressbar-loadbar-progress: 85%;
+  }
+
+  :root:has(.tabbrowser-tab[selected][busy]) {
+    --blended-addressbar-loadbar-progress: 15%;
+  }
+
+  :root:has(.tabbrowser-tab[selected][busy][pendingicon]) {
+    --blended-addressbar-loadbar-progress: 45%;
+  }
+
+  :root:has(.tabbrowser-tab[selected][busy][pendingicon][progress]) {
+    --blended-addressbar-loadbar-progress: 85%;
+  }
+
+  :root:has(.tabbrowser-tab[selected][busy][progress]) {
+    --blended-addressbar-loadbar-progress: 95%;
+  }
+
+  @media (-moz-pref("uc.loadbar.mode", "hidden")) {
+    #zen-loading-progress-bar {
+      display: none !important;
     }
-    &:has(.tabbrowser-tab[selected][busy][pendingicon]) {
-      --bar-colour: var(--blended-addressbar-loadbar-color, var(--zen-primary-color));
-      --bar-pcent: 45%;
+  }
+
+  @media (-moz-pref("uc.loadbar.mode", "progress")),
+    (-moz-pref("uc.loadbar.mode", "edge")) {
+    #zen-loading-progress-bar {
+      --zen-loading-progress-bar-color: var(--blended-addressbar-loadbar-color, var(--zen-primary-color));
+
+      display: block !important;
+      background: var(--blended-addressbar-loadbar-track-color) !important;
+      opacity: var(--blended-addressbar-loadbar-opacity, 0.85) !important;
+      height: var(--blended-addressbar-loadbar-height, 2px) !important;
+      z-index: 9 !important;
+      overflow: clip !important;
+      pointer-events: none !important;
+      animation: none !important;
+      contain: content !important;
+      transition:
+        opacity 0.2s ease-in-out,
+        width 0.35s ease-in-out,
+        transform 0.25s ease-in-out,
+        background-color 0.2s ease-in-out !important;
+
+      &::before {
+        content: "" !important;
+        position: absolute !important;
+        inset: 0 auto 0 0 !important;
+        display: block !important;
+        width: var(--blended-addressbar-loadbar-progress) !important;
+        height: 100% !important;
+        background: var(--zen-loading-progress-bar-color) !important;
+        border-radius: inherit !important;
+        opacity: 1 !important;
+        animation: none !important;
+        transition: width 0.35s ease-in-out !important;
+      }
+
+      &[long-load="false"],
+      &:not([long-load="true"]) {
+        background: var(--blended-addressbar-loadbar-track-color) !important;
+        animation: none !important;
+      }
+
+      &[long-load="true"] {
+        background: var(--blended-addressbar-loadbar-track-color) !important;
+        animation: none !important;
+      }
     }
-    &:has(.tabbrowser-tab[selected][busy][pendingicon][progress]) {
-      --bar-colour: var(--blended-addressbar-loadbar-color, var(--zen-primary-color));
-      --bar-pcent: 85%;
+
+    :root:not(:has(.tabbrowser-tab[selected][busy])) #zen-loading-progress-bar {
+      opacity: 0 !important;
     }
-    &:has(.tabbrowser-tab[selected][busy][progress]) {
-      --bar-colour: var(--blended-addressbar-loadbar-color, var(--zen-primary-color));
-      --bar-pcent: 95%;
+
+    @media (-moz-bool-pref: "uc.loadbar.shadow") {
+      #zen-loading-progress-bar {
+        filter: drop-shadow(0 0 10px color-mix(in srgb, var(--zen-loading-progress-bar-color) 60%, transparent)) !important;
+      }
     }
-    &:has(.tabbrowser-tab[selected][muted]:not([busy])) {
-      --bar-colour: orangered;
-      --bar-pcent: 100%;
-      
-      .browserSidebarContainer.deck-selected::before {
-        border-radius: 0;
+
+    @media not (-moz-bool-pref: "uc.loadbar.roundedcorner") {
+      #zen-loading-progress-bar {
+        border-radius: 0 !important;
       }
     }
   }
 
-  /* 
-     When we are in compact mode, but not in single-toolbar mode,
-     hide the loading bar while the toolbar or URL bubble is currently showing.
+  @media (-moz-pref("uc.loadbar.mode", "progress")) {
+    #zen-loading-progress-bar {
+      position: fixed !important;
+      top: calc(var(--blended-addressbar-frame-gap, 5px) + var(--urlbar-container-height, 40px) - var(--blended-addressbar-loadbar-height, 2px)) !important;
+      left: 50% !important;
+      width: min(18rem, 42vw) !important;
+      border-radius: 100px !important;
+      transform: translateX(-50%) !important;
+    }
 
-     This uses the conditionals found in /src/zen/compact-mode/zen-compact-mode.css
-     to detect if the toolbar is showing.
-  */
-  @media (-moz-bool-pref: "zen.view.compact.hide-toolbar") {
-    :root:not([zen-single-toolbar='true']):has([zen-compact-mode='true']) {
-      &:has(#zen-appcontent-navbar-wrapper[zen-has-hover]),
-      &:has(#zen-appcontent-navbar-wrapper[zen-user-show]),
-      &:has(#zen-appcontent-navbar-wrapper[has-popup-menu]),
-      &:has(*:is(#zen-appcontent-navbar-wrapper[panelopen='true'], 
-                 #zen-appcontent-navbar-wrapper[open='true'], 
-                 #urlbar:focus-within:not(#urlbar[zen-floating-urlbar='true']), 
-                 #zen-appcontent-navbar-wrapper[breakout-extend='true'])
-            :not(.zen-compact-mode-ignore)
-      ) {
-        .browserSidebarContainer.deck-selected::before {
-          opacity: 0 !important;
-          top: 0px !important;
-        }
+    :root:not(:has(.tabbrowser-tab[selected][busy])) #zen-loading-progress-bar {
+      transform: translateX(-50%) scaleX(0.98) !important;
+    }
+  }
+
+  @media (-moz-pref("uc.loadbar.mode", "edge")) {
+    #zen-loading-progress-bar {
+      display: none !important;
+    }
+
+    #zen-appcontent-navbar-wrapper {
+      position: relative !important;
+    }
+
+    #zen-appcontent-navbar-wrapper::before {
+      content: "" !important;
+      position: absolute !important;
+      top: 0 !important;
+      left: 0 !important;
+      width: var(--blended-addressbar-loadbar-progress) !important;
+      max-width: 100% !important;
+      height: var(--blended-addressbar-loadbar-height, 2px) !important;
+      background: var(--zen-tab-header-foreground, var(--blended-addressbar-page-loadbar-foreground, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)))) !important;
+      opacity: var(--blended-addressbar-loadbar-opacity, 0.85) !important;
+      z-index: 2 !important;
+      pointer-events: none !important;
+      border-radius: 0 var(--blended-addressbar-loadbar-height, 2px) var(--blended-addressbar-loadbar-height, 2px) 0 !important;
+      transform: none !important;
+      transition:
+        opacity 0.2s ease-in-out,
+        width 0.7s ease-in-out,
+        background-color 0.2s ease-in-out !important;
+    }
+
+    :root:not(:has(.tabbrowser-tab[selected][busy])) #zen-appcontent-navbar-wrapper::before {
+      width: 0 !important;
+      opacity: 0 !important;
+    }
+
+    @media (-moz-bool-pref: "uc.loadbar.shadow") {
+      #zen-appcontent-navbar-wrapper::before {
+        filter: drop-shadow(0 0 10px color-mix(in srgb, var(--zen-tab-header-foreground, var(--blended-addressbar-page-loadbar-foreground, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)))) 60%, transparent)) !important;
       }
     }
+
+    @media not (-moz-bool-pref: "uc.loadbar.roundedcorner") {
+      #zen-appcontent-navbar-wrapper::before {
+        border-radius: 0 !important;
+      }
+    }
+  }
+
+  @media (-moz-pref("uc.loadbar.mode", "glow")) {
+    #zen-loading-progress-bar {
+      display: none !important;
+    }
+
+    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) {
+      position: relative !important;
+    }
+
+    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) > .urlbar-background {
+      overflow: hidden !important;
+    }
+
+    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) > .urlbar-background::before,
+    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) > .urlbar-background::after {
+      content: "" !important;
+      position: absolute !important;
+      pointer-events: none !important;
+    }
+
+    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) > .urlbar-background::before {
+      inset: 0 !important;
+      border-radius: inherit !important;
+      background: color-mix(in srgb, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)) 9%, transparent) !important;
+      opacity: 0 !important;
+      z-index: 0 !important;
+      transition: opacity 0.2s ease-in-out !important;
+    }
+
+    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) > .urlbar-background::after {
+      left: 0 !important;
+      right: auto !important;
+      bottom: 0 !important;
+      width: var(--blended-addressbar-loadbar-progress) !important;
+      min-width: 0 !important;
+      max-width: 100% !important;
+      height: var(--blended-addressbar-loadbar-height, 2px) !important;
+      border-radius: 0 !important;
+      opacity: 0 !important;
+      z-index: 1 !important;
+      background:
+        linear-gradient(
+          90deg,
+          transparent 0%,
+          color-mix(in srgb, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)) 70%, white 30%) 46%,
+          transparent 76%
+        ),
+        color-mix(in srgb, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)) 96%, white 4%) !important;
+      background-repeat: no-repeat !important;
+      background-size: 6rem 100%, 100% 100% !important;
+      background-position: -6rem 0, 0 0;
+      box-shadow:
+        0 -8px 18px 5px color-mix(in srgb, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)) 34%, transparent),
+        0 -2px 8px 1px color-mix(in srgb, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)) 62%, transparent) !important;
+      mask-image: linear-gradient(90deg, black 0%, black calc(100% - 5rem), transparent 100%) !important;
+      transition:
+        opacity 0.2s ease-in-out,
+        width 0.35s ease-in-out !important;
+    }
+
+    :root:is(:has(.tabbrowser-tab[selected][busy]), :has(#zen-loading-progress-bar[long-load])) #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) > .urlbar-background::before {
+      opacity: 1 !important;
+    }
+
+    :root:is(:has(.tabbrowser-tab[selected][busy]), :has(#zen-loading-progress-bar[long-load])) #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) > .urlbar-background::after {
+      animation: blended-addressbar-loadbar-glow-sweep 1.35s ease-in-out infinite !important;
+      opacity: var(--blended-addressbar-loadbar-opacity, 0.85) !important;
+    }
+  }
+
+  :root[inDOMFullscreen="true"] #zen-loading-progress-bar {
+    display: none !important;
+  }
+
+  :root[inDOMFullscreen="true"] #zen-appcontent-navbar-wrapper::before {
+    display: none !important;
   }
 }

--- a/styles/loadbar.css
+++ b/styles/loadbar.css
@@ -1,20 +1,24 @@
 /* Loader bar */
 
 @-moz-document url-prefix("chrome:") {
-  @keyframes blended-addressbar-loadbar-glow-sweep {
-    from {
-      background-position: -6rem 0, 0 0;
-    }
-
-    to {
-      background-position: calc(100% + 6rem) 0, 0 0;
-    }
-  }
-
   :root {
     --blended-addressbar-loadbar-progress: 0%;
-    --blended-addressbar-loadbar-track-color: color-mix(in srgb, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)) 16%, transparent);
-    --blended-addressbar-loadbar-glow-color: color-mix(in srgb, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)) 46%, transparent);
+    --blended-addressbar-dynamic-loadbar-color: var(--zen-tab-header-foreground, var(--blended-addressbar-page-loadbar-foreground, var(--blended-addressbar-loadbar-static-color, var(--zen-primary-color))));
+    --blended-addressbar-loadbar-right-radius: 0px;
+    --blended-addressbar-loadbar-track-color: color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) 8%, transparent);
+    --blended-addressbar-loadbar-glow-strong-mix: 27.2%;
+    --blended-addressbar-loadbar-glow-medium-mix: 14.4%;
+    --blended-addressbar-loadbar-glow-weak-mix: 5.6%;
+  }
+
+  :root[data-blended-addressbar-loadbar-focus-color="true"] {
+    --blended-addressbar-dynamic-loadbar-color: var(--zen-primary-color);
+  }
+
+  @media (-moz-bool-pref: "uc.loadbar.roundedcorner") {
+    :root {
+      --blended-addressbar-loadbar-right-radius: var(--blended-addressbar-loadbar-height, 2px);
+    }
   }
 
   :root:has(#zen-loading-progress-bar[long-load="false"]) {
@@ -41,20 +45,11 @@
     --blended-addressbar-loadbar-progress: 95%;
   }
 
-  @media (-moz-pref("uc.loadbar.mode", "hidden")) {
+  :root[data-blended-addressbar-loadbar-mode="progress"] {
     #zen-loading-progress-bar {
-      display: none !important;
-    }
-  }
-
-  @media (-moz-pref("uc.loadbar.mode", "progress")),
-    (-moz-pref("uc.loadbar.mode", "edge")) {
-    #zen-loading-progress-bar {
-      --zen-loading-progress-bar-color: var(--blended-addressbar-loadbar-color, var(--zen-primary-color));
-
       display: block !important;
       background: var(--blended-addressbar-loadbar-track-color) !important;
-      opacity: var(--blended-addressbar-loadbar-opacity, 0.85) !important;
+      opacity: var(--blended-addressbar-loadbar-opacity, 0.8) !important;
       height: var(--blended-addressbar-loadbar-height, 2px) !important;
       z-index: 9 !important;
       overflow: clip !important;
@@ -63,7 +58,7 @@
       contain: content !important;
       transition:
         opacity 0.2s ease-in-out,
-        width 0.35s ease-in-out,
+        width 0.7s ease-in-out,
         transform 0.25s ease-in-out,
         background-color 0.2s ease-in-out !important;
 
@@ -74,11 +69,11 @@
         display: block !important;
         width: var(--blended-addressbar-loadbar-progress) !important;
         height: 100% !important;
-        background: var(--zen-loading-progress-bar-color) !important;
-        border-radius: inherit !important;
+        background: var(--blended-addressbar-dynamic-loadbar-color) !important;
+        border-radius: 0 var(--blended-addressbar-loadbar-right-radius, 0px) var(--blended-addressbar-loadbar-right-radius, 0px) 0 !important;
         opacity: 1 !important;
         animation: none !important;
-        transition: width 0.35s ease-in-out !important;
+        transition: width 0.7s ease-in-out !important;
       }
 
       &[long-load="false"],
@@ -93,13 +88,13 @@
       }
     }
 
-    :root:not(:has(.tabbrowser-tab[selected][busy])) #zen-loading-progress-bar {
+    &:not(:has(.tabbrowser-tab[selected][busy])) #zen-loading-progress-bar {
       opacity: 0 !important;
     }
 
     @media (-moz-bool-pref: "uc.loadbar.shadow") {
       #zen-loading-progress-bar {
-        filter: drop-shadow(0 0 10px color-mix(in srgb, var(--zen-loading-progress-bar-color) 60%, transparent)) !important;
+        filter: drop-shadow(0 0 10px color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) 60%, transparent)) !important;
       }
     }
 
@@ -110,43 +105,40 @@
     }
   }
 
-  @media (-moz-pref("uc.loadbar.mode", "progress")) {
+  :root[data-blended-addressbar-loadbar-mode="progress"] {
     #zen-loading-progress-bar {
       position: fixed !important;
-      top: calc(var(--blended-addressbar-frame-gap, 5px) + var(--urlbar-container-height, 40px) - var(--blended-addressbar-loadbar-height, 2px)) !important;
-      left: 50% !important;
-      width: min(18rem, 42vw) !important;
-      border-radius: 100px !important;
-      transform: translateX(-50%) !important;
+      top: 0 !important;
+      left: 0 !important;
+      width: 100vw !important;
+      border-radius: 0 !important;
+      transform: none !important;
     }
 
-    :root:not(:has(.tabbrowser-tab[selected][busy])) #zen-loading-progress-bar {
-      transform: translateX(-50%) scaleX(0.98) !important;
+    &:not(:has(.tabbrowser-tab[selected][busy])) #zen-loading-progress-bar {
+      transform: none !important;
     }
   }
 
-  @media (-moz-pref("uc.loadbar.mode", "edge")) {
+  :root[data-blended-addressbar-loadbar-mode="edge"] {
     #zen-loading-progress-bar {
       display: none !important;
     }
 
     #zen-appcontent-navbar-wrapper {
       position: relative !important;
+      overflow: visible !important;
     }
 
-    #zen-appcontent-navbar-wrapper::before {
+    #zen-appcontent-navbar-wrapper::before,
+    #zen-appcontent-navbar-wrapper::after {
       content: "" !important;
       position: absolute !important;
-      top: 0 !important;
       left: 0 !important;
+      right: auto !important;
       width: var(--blended-addressbar-loadbar-progress) !important;
       max-width: 100% !important;
-      height: var(--blended-addressbar-loadbar-height, 2px) !important;
-      background: var(--zen-tab-header-foreground, var(--blended-addressbar-page-loadbar-foreground, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)))) !important;
-      opacity: var(--blended-addressbar-loadbar-opacity, 0.85) !important;
-      z-index: 2 !important;
       pointer-events: none !important;
-      border-radius: 0 var(--blended-addressbar-loadbar-height, 2px) var(--blended-addressbar-loadbar-height, 2px) 0 !important;
       transform: none !important;
       transition:
         opacity 0.2s ease-in-out,
@@ -154,14 +146,39 @@
         background-color 0.2s ease-in-out !important;
     }
 
-    :root:not(:has(.tabbrowser-tab[selected][busy])) #zen-appcontent-navbar-wrapper::before {
+    #zen-appcontent-navbar-wrapper::before {
+      top: 0 !important;
+      height: var(--blended-addressbar-loadbar-height, 2px) !important;
+      background: var(--blended-addressbar-dynamic-loadbar-color) !important;
+      opacity: var(--blended-addressbar-loadbar-opacity, 0.8) !important;
+      border-radius: 0 var(--blended-addressbar-loadbar-right-radius, 0px) var(--blended-addressbar-loadbar-right-radius, 0px) 0 !important;
+      z-index: 2 !important;
+    }
+
+    #zen-appcontent-navbar-wrapper::after {
+      top: var(--blended-addressbar-loadbar-height, 2px) !important;
+      height: 24px !important;
+      opacity: 1 !important;
+      background:
+        linear-gradient(
+          to bottom,
+          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-strong-mix, 27.2%), transparent) 0%,
+          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-medium-mix, 14.4%), transparent) 36%,
+          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-weak-mix, 5.6%), transparent) 68%,
+          transparent 100%
+        ) !important;
+      z-index: 1 !important;
+    }
+
+    &:not(:has(.tabbrowser-tab[selected][busy])) #zen-appcontent-navbar-wrapper::before,
+    &:not(:has(.tabbrowser-tab[selected][busy])) #zen-appcontent-navbar-wrapper::after {
       width: 0 !important;
       opacity: 0 !important;
     }
 
     @media (-moz-bool-pref: "uc.loadbar.shadow") {
       #zen-appcontent-navbar-wrapper::before {
-        filter: drop-shadow(0 0 10px color-mix(in srgb, var(--zen-tab-header-foreground, var(--blended-addressbar-page-loadbar-foreground, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)))) 60%, transparent)) !important;
+        filter: drop-shadow(0 0 10px color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) 60%, transparent)) !important;
       }
     }
 
@@ -172,36 +189,55 @@
     }
   }
 
-  @media (-moz-pref("uc.loadbar.mode", "glow")) {
+  :root[data-blended-addressbar-loadbar-mode="glow"] {
     #zen-loading-progress-bar {
       display: none !important;
     }
 
-    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) {
+    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend]) {
       position: relative !important;
+      overflow: visible !important;
     }
 
-    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) > .urlbar-background {
+    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend]) > .urlbar-background {
+      background-color: transparent !important;
       overflow: hidden !important;
+      transition: background-color 0.2s ease-in-out !important;
     }
 
-    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) > .urlbar-background::before,
-    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) > .urlbar-background::after {
+    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend]) > .urlbar-background::before,
+    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend]) > .urlbar-background::after {
       content: "" !important;
       position: absolute !important;
       pointer-events: none !important;
     }
 
-    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) > .urlbar-background::before {
-      inset: 0 !important;
-      border-radius: inherit !important;
-      background: color-mix(in srgb, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)) 9%, transparent) !important;
+    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend]) > .urlbar-background::before {
+      top: 0 !important;
+      left: 0 !important;
+      right: auto !important;
+      bottom: 0 !important;
+      width: var(--blended-addressbar-loadbar-progress) !important;
+      min-width: 0 !important;
+      max-width: 100% !important;
+      border-radius: 0 var(--blended-addressbar-loadbar-right-radius, 0px) var(--blended-addressbar-loadbar-right-radius, 0px) 0 !important;
+      background:
+        linear-gradient(
+          to top,
+          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-strong-mix, 27.2%), transparent) 0%,
+          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-medium-mix, 14.4%), transparent) 36%,
+          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-weak-mix, 5.6%), transparent) 68%,
+          transparent 100%
+        ) !important;
       opacity: 0 !important;
       z-index: 0 !important;
-      transition: opacity 0.2s ease-in-out !important;
+      transition:
+        opacity 0.2s ease-in-out,
+        width 0.7s ease-in-out !important;
     }
 
-    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) > .urlbar-background::after {
+    #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend]) > .urlbar-background::after {
+      top: auto !important;
       left: 0 !important;
       right: auto !important;
       bottom: 0 !important;
@@ -209,36 +245,27 @@
       min-width: 0 !important;
       max-width: 100% !important;
       height: var(--blended-addressbar-loadbar-height, 2px) !important;
-      border-radius: 0 !important;
+      border-radius: 0 var(--blended-addressbar-loadbar-right-radius, 0px) var(--blended-addressbar-loadbar-right-radius, 0px) 0 !important;
       opacity: 0 !important;
       z-index: 1 !important;
-      background:
-        linear-gradient(
-          90deg,
-          transparent 0%,
-          color-mix(in srgb, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)) 70%, white 30%) 46%,
-          transparent 76%
-        ),
-        color-mix(in srgb, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)) 96%, white 4%) !important;
+      background: var(--blended-addressbar-dynamic-loadbar-color) !important;
       background-repeat: no-repeat !important;
-      background-size: 6rem 100%, 100% 100% !important;
-      background-position: -6rem 0, 0 0;
-      box-shadow:
-        0 -8px 18px 5px color-mix(in srgb, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)) 34%, transparent),
-        0 -2px 8px 1px color-mix(in srgb, var(--blended-addressbar-loadbar-color, var(--zen-primary-color)) 62%, transparent) !important;
-      mask-image: linear-gradient(90deg, black 0%, black calc(100% - 5rem), transparent 100%) !important;
+      background-size: 100% 100% !important;
       transition:
         opacity 0.2s ease-in-out,
-        width 0.35s ease-in-out !important;
+        width 0.7s ease-in-out !important;
     }
 
-    :root:is(:has(.tabbrowser-tab[selected][busy]), :has(#zen-loading-progress-bar[long-load])) #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) > .urlbar-background::before {
+    &:is(:has(.tabbrowser-tab[selected][busy]), :has(#zen-loading-progress-bar[long-load])) #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend]) > .urlbar-background {
+      background-color: color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-weak-mix, 5.6%), transparent) !important;
+    }
+
+    &:is(:has(.tabbrowser-tab[selected][busy]), :has(#zen-loading-progress-bar[long-load])) #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend]) > .urlbar-background::before {
       opacity: 1 !important;
     }
 
-    :root:is(:has(.tabbrowser-tab[selected][busy]), :has(#zen-loading-progress-bar[long-load])) #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend="true"]) > .urlbar-background::after {
-      animation: blended-addressbar-loadbar-glow-sweep 1.35s ease-in-out infinite !important;
-      opacity: var(--blended-addressbar-loadbar-opacity, 0.85) !important;
+    &:is(:has(.tabbrowser-tab[selected][busy]), :has(#zen-loading-progress-bar[long-load])) #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend]) > .urlbar-background::after {
+      opacity: var(--blended-addressbar-loadbar-opacity, 0.8) !important;
     }
   }
 
@@ -246,7 +273,4 @@
     display: none !important;
   }
 
-  :root[inDOMFullscreen="true"] #zen-appcontent-navbar-wrapper::before {
-    display: none !important;
-  }
 }

--- a/styles/loadbar.css
+++ b/styles/loadbar.css
@@ -7,9 +7,9 @@
     --blended-addressbar-loadbar-right-radius: 0px;
     --blended-addressbar-loadbar-edge-top-offset: 0px;
     --blended-addressbar-loadbar-track-color: color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) 8%, transparent);
-    --blended-addressbar-loadbar-glow-strong-mix: 27.2%;
-    --blended-addressbar-loadbar-glow-medium-mix: 14.4%;
-    --blended-addressbar-loadbar-glow-weak-mix: 5.6%;
+    --blended-addressbar-loadbar-glow-strong-mix: 34%;
+    --blended-addressbar-loadbar-glow-medium-mix: 18%;
+    --blended-addressbar-loadbar-glow-weak-mix: 7%;
   }
 
   :root[data-blended-addressbar-loadbar-focus-color="true"] {
@@ -56,7 +56,7 @@
     #zen-loading-progress-bar {
       display: block !important;
       background: var(--blended-addressbar-loadbar-track-color) !important;
-      opacity: var(--blended-addressbar-loadbar-opacity, 0.8) !important;
+      opacity: var(--blended-addressbar-loadbar-opacity, 1) !important;
       height: var(--blended-addressbar-loadbar-height, 2px) !important;
       z-index: 9 !important;
       overflow: clip !important;
@@ -157,7 +157,7 @@
       top: var(--blended-addressbar-loadbar-edge-top-offset, 0px) !important;
       height: var(--blended-addressbar-loadbar-height, 2px) !important;
       background: var(--blended-addressbar-dynamic-loadbar-color) !important;
-      opacity: var(--blended-addressbar-loadbar-opacity, 0.8) !important;
+      opacity: var(--blended-addressbar-loadbar-opacity, 1) !important;
       border-radius: 0 var(--blended-addressbar-loadbar-right-radius, 0px) var(--blended-addressbar-loadbar-right-radius, 0px) 0 !important;
       z-index: 2 !important;
     }
@@ -169,9 +169,9 @@
       background:
         linear-gradient(
           to bottom,
-          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-strong-mix, 27.2%), transparent) 0%,
-          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-medium-mix, 14.4%), transparent) 36%,
-          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-weak-mix, 5.6%), transparent) 68%,
+          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-strong-mix, 34%), transparent) 0%,
+          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-medium-mix, 18%), transparent) 36%,
+          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-weak-mix, 7%), transparent) 68%,
           transparent 100%
         ) !important;
       z-index: 1 !important;
@@ -231,9 +231,9 @@
       background:
         linear-gradient(
           to top,
-          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-strong-mix, 27.2%), transparent) 0%,
-          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-medium-mix, 14.4%), transparent) 36%,
-          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-weak-mix, 5.6%), transparent) 68%,
+          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-strong-mix, 34%), transparent) 0%,
+          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-medium-mix, 18%), transparent) 36%,
+          color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-weak-mix, 7%), transparent) 68%,
           transparent 100%
         ) !important;
       opacity: 0 !important;
@@ -264,7 +264,7 @@
     }
 
     &:is(:has(.tabbrowser-tab[selected][busy]), :has(#zen-loading-progress-bar[long-load])) #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend]) > .urlbar-background {
-      background-color: color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-weak-mix, 5.6%), transparent) !important;
+      background-color: color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) var(--blended-addressbar-loadbar-glow-weak-mix, 7%), transparent) !important;
     }
 
     &:is(:has(.tabbrowser-tab[selected][busy]), :has(#zen-loading-progress-bar[long-load])) #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend]) > .urlbar-background::before {
@@ -272,7 +272,7 @@
     }
 
     &:is(:has(.tabbrowser-tab[selected][busy]), :has(#zen-loading-progress-bar[long-load])) #urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend]) > .urlbar-background::after {
-      opacity: var(--blended-addressbar-loadbar-opacity, 0.8) !important;
+      opacity: var(--blended-addressbar-loadbar-opacity, 1) !important;
     }
   }
 

--- a/styles/loadbar.css
+++ b/styles/loadbar.css
@@ -5,6 +5,7 @@
     --blended-addressbar-loadbar-progress: 0%;
     --blended-addressbar-dynamic-loadbar-color: var(--zen-tab-header-foreground, var(--blended-addressbar-page-loadbar-foreground, var(--blended-addressbar-loadbar-static-color, var(--zen-primary-color))));
     --blended-addressbar-loadbar-right-radius: 0px;
+    --blended-addressbar-loadbar-edge-top-offset: 0px;
     --blended-addressbar-loadbar-track-color: color-mix(in srgb, var(--blended-addressbar-dynamic-loadbar-color) 8%, transparent);
     --blended-addressbar-loadbar-glow-strong-mix: 27.2%;
     --blended-addressbar-loadbar-glow-medium-mix: 14.4%;
@@ -18,6 +19,12 @@
   @media (-moz-bool-pref: "uc.loadbar.roundedcorner") {
     :root {
       --blended-addressbar-loadbar-right-radius: var(--blended-addressbar-loadbar-height, 2px);
+    }
+  }
+
+  @media (-moz-bool-pref: "uc.blended-addressbar.frame-padding.disabled") {
+    :root {
+      --blended-addressbar-loadbar-edge-top-offset: var(--blended-addressbar-loadbar-height, 2px);
     }
   }
 
@@ -147,7 +154,7 @@
     }
 
     #zen-appcontent-navbar-wrapper::before {
-      top: 0 !important;
+      top: var(--blended-addressbar-loadbar-edge-top-offset, 0px) !important;
       height: var(--blended-addressbar-loadbar-height, 2px) !important;
       background: var(--blended-addressbar-dynamic-loadbar-color) !important;
       opacity: var(--blended-addressbar-loadbar-opacity, 0.8) !important;
@@ -156,7 +163,7 @@
     }
 
     #zen-appcontent-navbar-wrapper::after {
-      top: var(--blended-addressbar-loadbar-height, 2px) !important;
+      top: calc(var(--blended-addressbar-loadbar-edge-top-offset, 0px) + var(--blended-addressbar-loadbar-height, 2px)) !important;
       height: 24px !important;
       opacity: 1 !important;
       background:

--- a/tests/native-theme.test.js
+++ b/tests/native-theme.test.js
@@ -571,7 +571,7 @@ test('loadbar modes customize the native Zen loading progress element', () => {
   assert.match(script, /const mode = readStringPref\(loadbarModePref,\s*defaultLoadbarMode\)/);
   assert.match(script, /const normalizedMode = normalizeLoadbarMode\(mode\)/);
   assert.match(script, /const height = normalizeCssLength\(readStringPref\(loadbarHeightPref,\s*'2px'\),\s*'2px'\)/);
-  assert.match(script, /const opacity = normalizeOpacity\(readStringPref\(loadbarOpacityPref,\s*'80'\),\s*'0\.8'\)/);
+  assert.match(script, /const opacity = normalizeOpacity\(readStringPref\(loadbarOpacityPref,\s*'100'\),\s*'1'\)/);
   assert.match(script, /const customColor = normalizeCssColor\(readStringPref\(loadbarColorPref,\s*'var\(--zen-primary-color\)'\),\s*'var\(--zen-primary-color\)'\)/);
   assert.match(script, /const useFocusColor = readBoolPref\(loadbarFocusColorPref,\s*true\)/);
   assert.match(script, /setStylePropertyIfChanged\(rootStyle,\s*'--blended-addressbar-loadbar-static-color',\s*customColor\)/);
@@ -600,9 +600,9 @@ test('loadbar modes customize the native Zen loading progress element', () => {
   assert.match(css, /@media \(-moz-bool-pref: "uc\.blended-addressbar\.frame-padding\.disabled"\)\s*\{[\s\S]*--blended-addressbar-loadbar-edge-top-offset:\s*var\(--blended-addressbar-loadbar-height,\s*2px\)/);
   assert.match(css, /@media \(-moz-bool-pref: "uc\.loadbar\.roundedcorner"\)\s*\{[\s\S]*--blended-addressbar-loadbar-right-radius:\s*var\(--blended-addressbar-loadbar-height,\s*2px\)/);
   assert.match(css, /:root\[data-blended-addressbar-loadbar-focus-color="true"\]\s*\{[^}]*--blended-addressbar-dynamic-loadbar-color:\s*var\(--zen-primary-color\)/);
-  assert.match(css, /--blended-addressbar-loadbar-glow-strong-mix:\s*27\.2%/);
-  assert.match(css, /--blended-addressbar-loadbar-glow-medium-mix:\s*14\.4%/);
-  assert.match(css, /--blended-addressbar-loadbar-glow-weak-mix:\s*5\.6%/);
+  assert.match(css, /--blended-addressbar-loadbar-glow-strong-mix:\s*34%/);
+  assert.match(css, /--blended-addressbar-loadbar-glow-medium-mix:\s*18%/);
+  assert.match(css, /--blended-addressbar-loadbar-glow-weak-mix:\s*7%/);
   assert.doesNotMatch(progressModeBlock, /--zen-loading-progress-bar-color/);
   assert.match(css, /--blended-addressbar-loadbar-track-color:\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) 8%,\s*transparent\)/);
   assert.doesNotMatch(progressModeBlock, /--blended-addressbar-loadbar-static-color/);
@@ -632,12 +632,12 @@ test('loadbar modes customize the native Zen loading progress element', () => {
   assert.match(css, /background:\s*var\(--blended-addressbar-dynamic-loadbar-color\)\s*!important/);
   assert.doesNotMatch(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before,\s*#zen-appcontent-navbar-wrapper::after\s*\{[^}]*opacity:\s*var\(--blended-addressbar-loadbar-opacity/);
   assert.doesNotMatch(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before,\s*#zen-appcontent-navbar-wrapper::after\s*\{[^}]*border-radius:/);
-  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before\s*\{[\s\S]*opacity:\s*var\(--blended-addressbar-loadbar-opacity,\s*0\.8\)\s*!important/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before\s*\{[\s\S]*opacity:\s*var\(--blended-addressbar-loadbar-opacity,\s*1\)\s*!important/);
   assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before\s*\{[\s\S]*border-radius:\s*0 var\(--blended-addressbar-loadbar-right-radius,\s*0px\) var\(--blended-addressbar-loadbar-right-radius,\s*0px\) 0\s*!important/);
   assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before,\s*#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*width 0\.7s ease-in-out/s);
   assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*height:\s*24px\s*!important/);
   assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*opacity:\s*1\s*!important/);
-  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*background:\s*linear-gradient\(\s*to bottom,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-strong-mix,\s*27\.2%\),\s*transparent\) 0%,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-medium-mix,\s*14\.4%\),\s*transparent\) 36%,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-weak-mix,\s*5\.6%\),\s*transparent\) 68%,\s*transparent 100%\s*\)\s*!important/s);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*background:\s*linear-gradient\(\s*to bottom,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-strong-mix,\s*34%\),\s*transparent\) 0%,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-medium-mix,\s*18%\),\s*transparent\) 36%,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-weak-mix,\s*7%\),\s*transparent\) 68%,\s*transparent 100%\s*\)\s*!important/s);
   assert.match(edgeModeBlock, /&:not\(:has\(\.tabbrowser-tab\[selected\]\[busy\]\)\) #zen-appcontent-navbar-wrapper::before,\s*&:not\(:has\(\.tabbrowser-tab\[selected\]\[busy\]\)\) #zen-appcontent-navbar-wrapper::after\s*\{[^}]*width:\s*0\s*!important;[^}]*opacity:\s*0\s*!important/s);
   assert.match(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background::before/);
   assert.match(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background::after/);
@@ -646,7 +646,7 @@ test('loadbar modes customize the native Zen loading progress element', () => {
   assert.match(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background\s*\{[^}]*overflow:\s*hidden\s*!important/s);
   assert.match(urlbarGlowBackgroundBlock, /background-color:\s*transparent\s*!important/);
   assert.match(urlbarGlowBackgroundBlock, /transition:\s*background-color 0\.2s ease-in-out\s*!important/);
-  assert.match(css, /&:is\(:has\(\.tabbrowser-tab\[selected\]\[busy\]\),\s*:has\(#zen-loading-progress-bar\[long-load\]\)\) #urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background\s*\{[^}]*background-color:\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-weak-mix,\s*5\.6%\),\s*transparent\)\s*!important/s);
+  assert.match(css, /&:is\(:has\(\.tabbrowser-tab\[selected\]\[busy\]\),\s*:has\(#zen-loading-progress-bar\[long-load\]\)\) #urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background\s*\{[^}]*background-color:\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-weak-mix,\s*7%\),\s*transparent\)\s*!important/s);
   assert.doesNotMatch(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background\s*\{[^}]*position:\s*relative/s);
   assert.doesNotMatch(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background\s*\{[^}]*background:/s);
   assert.doesNotMatch(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\) \.urlbar-background\s*\{[^}]*overflow:\s*hidden/s);
@@ -659,7 +659,7 @@ test('loadbar modes customize the native Zen loading progress element', () => {
   assert.match(urlbarGlowBeforeBlock, /max-width:\s*100%\s*!important/);
   assert.match(urlbarGlowBeforeBlock, /border-radius:\s*0 var\(--blended-addressbar-loadbar-right-radius,\s*0px\) var\(--blended-addressbar-loadbar-right-radius,\s*0px\) 0\s*!important/);
   assert.doesNotMatch(urlbarGlowBeforeBlock, /inset:\s*0\s*!important/);
-  assert.match(urlbarGlowBeforeBlock, /linear-gradient\(\s*to top,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-strong-mix,\s*27\.2%\),\s*transparent\) 0%,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-medium-mix,\s*14\.4%\),\s*transparent\) 36%,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-weak-mix,\s*5\.6%\),\s*transparent\) 68%,\s*transparent 100%\s*\)/s);
+  assert.match(urlbarGlowBeforeBlock, /linear-gradient\(\s*to top,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-strong-mix,\s*34%\),\s*transparent\) 0%,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-medium-mix,\s*18%\),\s*transparent\) 36%,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-weak-mix,\s*7%\),\s*transparent\) 68%,\s*transparent 100%\s*\)/s);
   assert.match(urlbarGlowBeforeBlock, /z-index:\s*0\s*!important/);
   assert.match(urlbarGlowBeforeBlock, /width 0\.7s ease-in-out/);
   assert.doesNotMatch(urlbarGlowBeforeBlock, /height:\s*24px\s*!important/);
@@ -708,7 +708,7 @@ test('loadbar modes customize the native Zen loading progress element', () => {
   assert.equal(loadbarFocusColorPreference.type, 'checkbox');
   assert.equal(loadbarFocusColorPreference.defaultValue, true);
   assert.equal(prefsJson.find((pref) => pref.property === 'uc.loadbar.height').defaultValue, '2px');
-  assert.equal(prefsJson.find((pref) => pref.property === 'uc.loadbar.opacity').defaultValue, '80');
+  assert.equal(prefsJson.find((pref) => pref.property === 'uc.loadbar.opacity').defaultValue, '100');
   assert.doesNotMatch(prefs, /uc\.loadbar\.color-source/);
   assert.doesNotMatch(prefs, /uc\.loadbar\.position/);
   assert.match(readme, /uc\.loadbar\.mode/);

--- a/tests/native-theme.test.js
+++ b/tests/native-theme.test.js
@@ -501,6 +501,60 @@ test('same effective tab theme updates are no-ops to avoid tab-switch blink', ()
   assert.doesNotMatch(script, /const key = getThemeKey\(theme\);\s*chromeDoc\.documentElement\.style\.setProperty\('--blended-addressbar-frame-background',\s*'transparent',\s*'important'\);\s*if \(key === lastThemeKey\)/);
 });
 
+test('loadbar modes customize the native Zen loading progress element', () => {
+  const script = read('blended-bar.uc.js');
+  const css = readStyleWithImports();
+  const prefs = read('preferences.json');
+  const prefsJson = JSON.parse(prefs);
+  const loadbarModePreference = prefsJson.find((pref) => pref.property === 'uc.loadbar.mode');
+  const readme = read('README.md');
+
+  assert.match(script, /const loadbarModePref = `\$\{loadbarPrefBranch\}mode`/);
+  assert.match(script, /const loadbarModeValues = Object\.freeze\(new Set\(\['hidden', 'progress', 'glow', 'edge'\]\)\)/);
+  assert.match(script, /const normalizedMode = loadbarModeValues\.has\(mode\) \? mode : ''/);
+  assert.match(script, /data-blended-addressbar-loadbar-mode/);
+  assert.match(css, /#zen-loading-progress-bar/);
+  assert.match(css, /@media \(-moz-pref\("uc\.loadbar\.mode", "hidden"\)\)/);
+  assert.match(css, /@media \(-moz-pref\("uc\.loadbar\.mode", "progress"\)\)/);
+  assert.match(css, /@media \(-moz-pref\("uc\.loadbar\.mode", "edge"\)\)/);
+  assert.match(css, /@media \(-moz-pref\("uc\.loadbar\.mode", "glow"\)\)/);
+  assert.match(css, /&\[long-load="false"\]/);
+  assert.match(css, /&\[long-load="true"\]/);
+  assert.match(css, /:root:has\(#zen-loading-progress-bar\[long-load="false"\]\)/);
+  assert.match(css, /:root:has\(#zen-loading-progress-bar\[long-load="true"\]\)/);
+  assert.doesNotMatch(css, /--blended-addressbar-loadbar-progress:\s*max\(var\(--blended-addressbar-loadbar-progress\)/);
+  assert.match(css, /#zen-appcontent-navbar-wrapper::before/);
+  assert.match(css, /max-width:\s*100%\s*!important/);
+  assert.match(css, /background:\s*var\(--zen-tab-header-foreground,\s*var\(--blended-addressbar-page-loadbar-foreground/);
+  assert.match(css, /#zen-appcontent-navbar-wrapper::before\s*\{[\s\S]*width 0\.7s ease-in-out/s);
+  assert.match(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend="true"\]\) > \.urlbar-background::before/);
+  assert.match(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend="true"\]\) > \.urlbar-background::after/);
+  assert.match(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend="true"\]\) > \.urlbar-background\s*\{[^}]*overflow:\s*hidden\s*!important/s);
+  assert.doesNotMatch(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend="true"\]\) > \.urlbar-background\s*\{[^}]*position:\s*relative/s);
+  assert.doesNotMatch(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend="true"\]\) > \.urlbar-background\s*\{[^}]*background:/s);
+  assert.doesNotMatch(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\) \.urlbar-background\s*\{[^}]*overflow:\s*hidden/s);
+  assert.match(css, /height:\s*var\(--blended-addressbar-loadbar-height,\s*2px\)\s*!important/);
+  assert.match(css, /border-radius:\s*0\s*!important/);
+  assert.match(css, /color-mix\(in srgb, var\(--blended-addressbar-loadbar-color, var\(--zen-primary-color\)\) 70%, white 30%\)/);
+  assert.doesNotMatch(css, /white\s+\d+%,\s*transparent/);
+  assert.match(css, /color-mix\(in srgb, var\(--blended-addressbar-loadbar-color, var\(--zen-primary-color\)\) 96%, white 4%\)/);
+  assert.doesNotMatch(css, /border-bottom:\s*var\(--blended-addressbar-loadbar-height/);
+  assert.match(css, /mask-image:\s*linear-gradient\(90deg,\s*black 0%,\s*black calc\(100% - 5rem\),\s*transparent 100%\)/);
+  assert.match(css, /:root:is\(:has\(\.tabbrowser-tab\[selected\]\[busy\]\),\s*:has\(#zen-loading-progress-bar\[long-load\]\)\)/);
+  assert.match(css, /--blended-addressbar-loadbar-progress:\s*95%/);
+  assert.doesNotMatch(css, /uc\.loadbar\.mode", "zen"/);
+  assert.match(css, /:root\[inDOMFullscreen="true"\] #zen-loading-progress-bar/);
+  assert.doesNotMatch(css, /\.browserSidebarContainer\.deck-selected::before/);
+  assert.match(prefs, /uc\.loadbar\.mode/);
+  assert.equal(loadbarModePreference.defaultValue, undefined);
+  assert.deepEqual(loadbarModePreference.options.map((option) => option.value), ['hidden', 'progress', 'glow', 'edge']);
+  assert.deepEqual(loadbarModePreference.options.map((option) => option.label), ['Hidden', 'Progress bar', 'URL bar glow', 'Window edge']);
+  assert.doesNotMatch(prefs, /uc\.loadbar\.position/);
+  assert.match(readme, /uc\.loadbar\.mode/);
+  assert.match(readme, /Sine's built-in None keeps Zen's default loader/);
+  assert.doesNotMatch(readme, /uc\.loadbar\.position/);
+});
+
 test('theme debug attributes are written through one helper', () => {
   const script = read('blended-bar.uc.js');
 

--- a/tests/native-theme.test.js
+++ b/tests/native-theme.test.js
@@ -36,6 +36,21 @@ function cssRuleBlock(css, selector) {
   return css.slice(openIndex + 1, closeIndex);
 }
 
+function cssRuleBlockOccurrence(css, selector, occurrence) {
+  let selectorIndex = -1;
+  let searchStart = 0;
+  for (let index = 0; index <= occurrence; index += 1) {
+    selectorIndex = css.indexOf(selector, searchStart);
+    assert.notEqual(selectorIndex, -1, `missing selector occurrence ${occurrence}: ${selector}`);
+    searchStart = selectorIndex + selector.length;
+  }
+  const openIndex = css.indexOf('{', selectorIndex);
+  assert.notEqual(openIndex, -1, `missing opening brace for selector occurrence ${occurrence}: ${selector}`);
+  const closeIndex = css.indexOf('}', openIndex);
+  assert.notEqual(closeIndex, -1, `missing closing brace for selector occurrence ${occurrence}: ${selector}`);
+  return css.slice(openIndex + 1, closeIndex);
+}
+
 function cssSelectorPrelude(css, selectorStart) {
   const selectorIndex = css.indexOf(selectorStart);
   assert.notEqual(selectorIndex, -1, `missing selector start: ${selectorStart}`);
@@ -56,12 +71,12 @@ test('browser window tint bridges page colors through native Zen window theme va
 
   assert.match(script, /const windowTintEnabledPref = `\$\{addressbarPrefBranch\}window-tint\.enabled`/);
   assert.match(script, /const windowTintStrengthPref = `\$\{addressbarPrefBranch\}window-tint\.strength`/);
-  assert.match(script, /const legacySidebarEnabledPref = `\$\{addressbarPrefBranch\}sidebar\.enabled`/);
   assert.match(script, /function readWindowTintEnabled\(/);
-  assert.match(script, /function migrateWindowTintPref\(/);
+  assert.doesNotMatch(script, /legacySidebarEnabledPref/);
+  assert.doesNotMatch(script, /sidebar\.enabled/);
+  assert.doesNotMatch(script, /function migrateWindowTintPref\(/);
   assert.match(script, /changedPref !== windowTintEnabledPref/);
   assert.match(script, /changedPref !== windowTintStrengthPref/);
-  assert.match(script, /changedPref !== legacySidebarEnabledPref/);
   assert.match(script, /const defaultWindowTintStrengthPercent = 25/);
   assert.match(script, /function readWindowTintStrengthPercent\(/);
   assert.match(script, /normalizePercent\(readStringPref\(windowTintStrengthPref,\s*String\(defaultWindowTintStrengthPercent\)\),\s*defaultWindowTintStrengthPercent,\s*0,\s*100\)/);
@@ -85,6 +100,10 @@ test('browser window tint bridges page colors through native Zen window theme va
   assert.doesNotMatch(script, /macosWindowMaterialPref/);
   assert.doesNotMatch(script, /getMacosWindowMaterialTheme/);
   assert.doesNotMatch(script, /--blended-addressbar-sidebar-page-color/);
+  assert.doesNotMatch(script, /selectorRulePref/);
+  assert.doesNotMatch(script, /selector-rule/);
+  assert.doesNotMatch(script, /getSelectorRuleTheme/);
+  assert.doesNotMatch(script, /parseSelectorRule/);
   assert.match(css, /#zen-browser-background::before\s*\{[^}]*background:\s*linear-gradient\(var\(--blended-addressbar-window-tint-background,\s*transparent\),\s*var\(--blended-addressbar-window-tint-background,\s*transparent\)\),\s*var\(--zen-main-browser-background-old\)\s*!important/s);
   assert.match(css, /#zen-browser-background::after\s*\{[^}]*background:\s*linear-gradient\(var\(--blended-addressbar-window-tint-background,\s*transparent\),\s*var\(--blended-addressbar-window-tint-background,\s*transparent\)\),\s*var\(--zen-main-browser-background\)\s*!important/s);
   assert.doesNotMatch(css, /@media \(-moz-bool-pref: "uc\.blended-addressbar\.window-tint\.enabled"\)/);
@@ -172,17 +191,26 @@ test('focused helper modules expose the expected subscript contract', () => {
   assert.equal(sourcePolicy.isPixelThemeSource('top-visible'), false);
   assert.equal(sourcePolicy.isPixelThemeSource({ source: 'host-cache', cachedSource: 'pixel-top-edge' }), true);
   assert.equal(sourcePolicy.isPixelThemeSource({ source: 'host-cache', cachedSource: 'top-visible' }), false);
+  assert.equal(sourcePolicy.getColorSourcePolicy('selector-rule').sourceClass, 'unknown');
+  assert.equal(sourcePolicy.isPreferredSemanticThemeSource('selector-rule'), false);
 
   const prefs = loadScriptModule('prefs.js', {
     getServices: () => null,
     window: { CSS: { supports: () => true } }
   });
   assert.equal(typeof prefs.readStringPref, 'function');
-  assert.equal(typeof prefs.writeStringPref, 'function');
-  assert.equal(typeof prefs.clearUserPref, 'function');
+  assert.equal(prefs.writeStringPref, undefined);
+  assert.equal(prefs.clearUserPref, undefined);
+  assert.equal(prefs.prefHasUserValue, undefined);
+  assert.equal(prefs.readIntPref, undefined);
   assert.equal(typeof prefs.normalizeCssLength, 'function');
   assert.equal(typeof prefs.normalizeFrameShadowPreset, 'function');
+  assert.equal(typeof prefs.normalizeLoadbarMode, 'function');
   assert.equal(prefs.normalizeFrameShadowPreset('unexpected'), 'standard');
+  assert.equal(prefs.normalizeLoadbarMode('default'), 'default');
+  assert.equal(prefs.normalizeLoadbarMode('none'), 'default');
+  assert.equal(prefs.normalizeLoadbarMode('progress'), 'progress');
+  assert.equal(prefs.normalizeLoadbarMode('unexpected'), 'glow');
 
   const colorUtils = loadScriptModule('color-utils.js', {
     cssSupports: () => true,
@@ -367,6 +395,9 @@ test('frame shadow is selected through constrained dropdown presets', () => {
   const css = read('style.css');
   const script = `${read('blended-bar.uc.js')}\n${read('scripts/prefs.js')}`;
   const prefs = read('preferences.json');
+  const prefsJson = JSON.parse(prefs);
+  const frameShadowPreference = prefsJson.find((pref) => pref.property === 'uc.blended-addressbar.frame-shadow');
+  const prefsModule = loadScriptModule('prefs.js');
 
   assert.match(script, /const frameShadowPref = `\$\{addressbarPrefBranch\}frame-shadow`/);
   assert.match(script, /function normalizeFrameShadowPreset\(/);
@@ -375,19 +406,20 @@ test('frame shadow is selected through constrained dropdown presets', () => {
   assert.match(css, /--blended-addressbar-frame-shadow-minimal:/);
   assert.match(css, /:root:not\(\[zen-should-be-dark-mode\]\)\s*\{[^}]*--blended-addressbar-frame-shadow-minimal:\s*0 0 0 1px rgba\(0,\s*0,\s*0,\s*0\.08\),\s*0 1px 2px rgba\(0,\s*0,\s*0,\s*0\.05\)/s);
   assert.match(css, /--blended-addressbar-frame-shadow-medium:/);
-  assert.match(css, /\[data-blended-addressbar-frame-shadow="none"\]/);
-  assert.match(css, /--blended-addressbar-frame-shadow:\s*none/);
+  assert.doesNotMatch(css, /\[data-blended-addressbar-frame-shadow="none"\]/);
+  assert.doesNotMatch(css, /--blended-addressbar-frame-shadow:\s*none/);
   assert.match(prefs, /uc\.blended-addressbar\.frame-shadow/);
-  assert.match(prefs, /"label": "No shadow"/);
-  assert.match(prefs, /"label": "Standard"/);
-  assert.match(prefs, /"label": "Minimal"/);
-  assert.match(prefs, /"label": "Medium"/);
+  assert.equal(frameShadowPreference.defaultValue, 'standard');
+  assert.deepEqual(frameShadowPreference.options.map((option) => option.value), ['standard', 'minimal', 'medium']);
+  assert.deepEqual(frameShadowPreference.options.map((option) => option.label), ['Standard', 'Minimal', 'Medium']);
+  assert.equal(prefsModule.normalizeFrameShadowPreset('none'), 'standard');
 });
 
 test('page color caching is in-memory only and has no long-lived site color preference', () => {
   const script = read('blended-bar.uc.js');
   const prefs = read('preferences.json');
   const readme = read('README.md');
+  const architecture = read('docs/color-architecture.md');
 
   assert.doesNotMatch(script, /rememberPageColorsPref/);
   assert.doesNotMatch(script, /rememberSiteColorsLongerPref/);
@@ -422,6 +454,10 @@ test('page color caching is in-memory only and has no long-lived site color pref
   assert.doesNotMatch(readme, /uc\.blended-addressbar\.remember-site-colors-longer/);
   assert.doesNotMatch(readme, /remembered site colors across browser restarts/);
   assert.doesNotMatch(readme, /uc\.blended-addressbar\.clear-cache-request/);
+  assert.doesNotMatch(architecture, /uc\.blended-addressbar\.remember-site-colors-longer/);
+  assert.doesNotMatch(architecture, /remember-site-colors-longer/);
+  assert.doesNotMatch(architecture, /site-theme-cache/);
+  assert.doesNotMatch(architecture, /selector-rule/);
 });
 
 test('remembered tab colors are delayed in-session fallbacks instead of the first tab-switch paint', () => {
@@ -495,7 +531,7 @@ test('same effective tab theme updates are no-ops to avoid tab-switch blink', ()
   assert.match(script, /removeStylePropertyIfChanged\(rootStyle,\s*'--blended-addressbar-page-loadbar-background'\)/);
   assert.match(script, /setStylePropertyIfChanged\(rootStyle,\s*'--blended-addressbar-page-loadbar-foreground',\s*theme\.fg\)/);
   assert.match(script, /setStylePropertyIfChanged\(rootStyle,\s*'--blended-addressbar-frame-radius',\s*radius\)/);
-  assert.match(script, /setStylePropertyIfChanged\(rootStyle,\s*'--blended-addressbar-loadbar-color',\s*colorValue\)/);
+  assert.match(script, /setStylePropertyIfChanged\(rootStyle,\s*'--blended-addressbar-loadbar-static-color',\s*customColor\)/);
   assert.match(script, /if \(key === lastThemeKey\) \{\s*lastAppliedTheme = theme;\s*return true;\s*\}/);
   assert.match(script, /if \(key === lastThemeKey && getCurrentFrameBackground\(\) === 'transparent'\) \{\s*lastAppliedTheme = theme;\s*return true;\s*\}/);
   assert.doesNotMatch(script, /const key = getThemeKey\(theme\);\s*chromeDoc\.documentElement\.style\.setProperty\('--blended-addressbar-frame-background',\s*'transparent',\s*'important'\);\s*if \(key === lastThemeKey\)/);
@@ -507,51 +543,182 @@ test('loadbar modes customize the native Zen loading progress element', () => {
   const prefs = read('preferences.json');
   const prefsJson = JSON.parse(prefs);
   const loadbarModePreference = prefsJson.find((pref) => pref.property === 'uc.loadbar.mode');
+  const loadbarColorSourcePreference = prefsJson.find((pref) => pref.property === 'uc.loadbar.color-source');
+  const loadbarColorPreference = prefsJson.find((pref) => pref.property === 'uc.loadbar.color');
+  const loadbarFocusColorPreference = prefsJson.find((pref) => pref.property === 'uc.loadbar.focus-color');
+  const urlbarGlowBackgroundSelector = '#urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend]) > .urlbar-background';
+  const urlbarGlowBeforeSelector = '#urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend]) > .urlbar-background::before';
+  const urlbarGlowAfterSelector = '#urlbar:not([zen-floating-urlbar="true"]):not([breakout-extend]) > .urlbar-background::after';
+  const urlbarGlowBackgroundBlock = cssRuleBlockOccurrence(css, urlbarGlowBackgroundSelector, 0);
+  const urlbarGlowBeforeBlock = cssRuleBlockOccurrence(css, urlbarGlowBeforeSelector, 1);
+  const urlbarGlowAfterBlock = cssRuleBlockOccurrence(css, urlbarGlowAfterSelector, 1);
+  const progressModeStart = css.indexOf(':root[data-blended-addressbar-loadbar-mode="progress"]');
+  const edgeModeStart = css.indexOf(':root[data-blended-addressbar-loadbar-mode="edge"]');
+  const glowModeStart = css.indexOf(':root[data-blended-addressbar-loadbar-mode="glow"]');
+  assert.notEqual(progressModeStart, -1, 'missing progress loadbar mode block');
+  assert.notEqual(edgeModeStart, -1, 'missing edge loadbar mode block');
+  assert.notEqual(glowModeStart, -1, 'missing glow loadbar mode block');
+  const progressModeBlock = css.slice(progressModeStart, edgeModeStart);
+  const edgeModeBlock = css.slice(edgeModeStart, glowModeStart);
   const readme = read('README.md');
 
   assert.match(script, /const loadbarModePref = `\$\{loadbarPrefBranch\}mode`/);
-  assert.match(script, /const loadbarModeValues = Object\.freeze\(new Set\(\['hidden', 'progress', 'glow', 'edge'\]\)\)/);
-  assert.match(script, /const normalizedMode = loadbarModeValues\.has\(mode\) \? mode : ''/);
+  assert.match(script, /const loadbarFocusColorPref = `\$\{loadbarPrefBranch\}focus-color`/);
+  assert.match(script, /const defaultLoadbarMode = 'glow'/);
+  assert.doesNotMatch(script, /const loadbarModeValues = Object\.freeze/);
+  assert.doesNotMatch(script, /loadbarColorSourcePref/);
+  assert.doesNotMatch(script, /loadbarColorSourceValues/);
+  assert.match(script, /const mode = readStringPref\(loadbarModePref,\s*defaultLoadbarMode\)/);
+  assert.match(script, /const normalizedMode = normalizeLoadbarMode\(mode\)/);
+  assert.match(script, /const height = normalizeCssLength\(readStringPref\(loadbarHeightPref,\s*'2px'\),\s*'2px'\)/);
+  assert.match(script, /const opacity = normalizeOpacity\(readStringPref\(loadbarOpacityPref,\s*'80'\),\s*'0\.8'\)/);
+  assert.match(script, /const customColor = normalizeCssColor\(readStringPref\(loadbarColorPref,\s*'var\(--zen-primary-color\)'\),\s*'var\(--zen-primary-color\)'\)/);
+  assert.match(script, /const useFocusColor = readBoolPref\(loadbarFocusColorPref,\s*true\)/);
+  assert.match(script, /setStylePropertyIfChanged\(rootStyle,\s*'--blended-addressbar-loadbar-static-color',\s*customColor\)/);
+  assert.match(script, /function getLoadbarGlowMix\(opacity,\s*percent\)/);
+  assert.match(script, /setStylePropertyIfChanged\(rootStyle,\s*'--blended-addressbar-loadbar-glow-strong-mix',\s*getLoadbarGlowMix\(opacity,\s*34\)\)/);
+  assert.match(script, /setStylePropertyIfChanged\(rootStyle,\s*'--blended-addressbar-loadbar-glow-medium-mix',\s*getLoadbarGlowMix\(opacity,\s*18\)\)/);
+  assert.match(script, /setStylePropertyIfChanged\(rootStyle,\s*'--blended-addressbar-loadbar-glow-weak-mix',\s*getLoadbarGlowMix\(opacity,\s*7\)\)/);
+  assert.match(script, /root\.setAttribute\('data-blended-addressbar-loadbar-focus-color',\s*String\(useFocusColor\)\)/);
+  assert.doesNotMatch(script, /data-blended-addressbar-loadbar-color-source/);
   assert.match(script, /data-blended-addressbar-loadbar-mode/);
   assert.match(css, /#zen-loading-progress-bar/);
-  assert.match(css, /@media \(-moz-pref\("uc\.loadbar\.mode", "hidden"\)\)/);
-  assert.match(css, /@media \(-moz-pref\("uc\.loadbar\.mode", "progress"\)\)/);
-  assert.match(css, /@media \(-moz-pref\("uc\.loadbar\.mode", "edge"\)\)/);
-  assert.match(css, /@media \(-moz-pref\("uc\.loadbar\.mode", "glow"\)\)/);
+  assert.doesNotMatch(css, /uc\.loadbar\.mode", "hidden"/);
+  assert.match(css, /:root\[data-blended-addressbar-loadbar-mode="progress"\]/);
+  assert.match(css, /:root\[data-blended-addressbar-loadbar-mode="edge"\]/);
+  assert.match(css, /:root\[data-blended-addressbar-loadbar-mode="glow"\]/);
+  assert.doesNotMatch(css, /:root\[data-blended-addressbar-loadbar-mode="default"\]/);
+  assert.doesNotMatch(css, /data-blended-addressbar-loadbar-mode="hidden"/);
   assert.match(css, /&\[long-load="false"\]/);
   assert.match(css, /&\[long-load="true"\]/);
   assert.match(css, /:root:has\(#zen-loading-progress-bar\[long-load="false"\]\)/);
   assert.match(css, /:root:has\(#zen-loading-progress-bar\[long-load="true"\]\)/);
   assert.doesNotMatch(css, /--blended-addressbar-loadbar-progress:\s*max\(var\(--blended-addressbar-loadbar-progress\)/);
-  assert.match(css, /#zen-appcontent-navbar-wrapper::before/);
+  assert.match(css, /--blended-addressbar-dynamic-loadbar-color:\s*var\(--zen-tab-header-foreground,\s*var\(--blended-addressbar-page-loadbar-foreground,\s*var\(--blended-addressbar-loadbar-static-color,\s*var\(--zen-primary-color\)\)\)\)/);
+  assert.match(css, /--blended-addressbar-loadbar-right-radius:\s*0px/);
+  assert.match(css, /@media \(-moz-bool-pref: "uc\.loadbar\.roundedcorner"\)\s*\{[\s\S]*--blended-addressbar-loadbar-right-radius:\s*var\(--blended-addressbar-loadbar-height,\s*2px\)/);
+  assert.match(css, /:root\[data-blended-addressbar-loadbar-focus-color="true"\]\s*\{[^}]*--blended-addressbar-dynamic-loadbar-color:\s*var\(--zen-primary-color\)/);
+  assert.match(css, /--blended-addressbar-loadbar-glow-strong-mix:\s*27\.2%/);
+  assert.match(css, /--blended-addressbar-loadbar-glow-medium-mix:\s*14\.4%/);
+  assert.match(css, /--blended-addressbar-loadbar-glow-weak-mix:\s*5\.6%/);
+  assert.doesNotMatch(progressModeBlock, /--zen-loading-progress-bar-color/);
+  assert.match(css, /--blended-addressbar-loadbar-track-color:\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) 8%,\s*transparent\)/);
+  assert.doesNotMatch(progressModeBlock, /--blended-addressbar-loadbar-static-color/);
+  assert.match(progressModeBlock, /&::before\s*\{[\s\S]*background:\s*var\(--blended-addressbar-dynamic-loadbar-color\)\s*!important/);
+  assert.match(progressModeBlock, /filter:\s*drop-shadow\(0 0 10px color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) 60%,\s*transparent\)\)\s*!important/);
+  assert.match(css, /#zen-loading-progress-bar\s*\{[\s\S]*top:\s*0\s*!important[\s\S]*width:\s*100vw\s*!important[\s\S]*border-radius:\s*0\s*!important/);
+  assert.match(css, /&::before\s*\{[\s\S]*border-radius:\s*0 var\(--blended-addressbar-loadbar-right-radius,\s*0px\) var\(--blended-addressbar-loadbar-right-radius,\s*0px\) 0\s*!important/);
+  assert.doesNotMatch(css, /width 0\.35s ease-in-out/);
+  assert.match(progressModeBlock, /width 0\.7s ease-in-out/);
+  assert.match(edgeModeBlock, /#zen-loading-progress-bar\s*\{[^}]*display:\s*none\s*!important/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper\s*\{[^}]*position:\s*relative\s*!important/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::after/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before,\s*#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*position:\s*absolute\s*!important/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before,\s*#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*width:\s*var\(--blended-addressbar-loadbar-progress\)\s*!important/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before,\s*#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*max-width:\s*100%\s*!important/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before\s*\{[\s\S]*top:\s*0\s*!important/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*top:\s*var\(--blended-addressbar-loadbar-height,\s*2px\)\s*!important/);
+  assert.doesNotMatch(edgeModeBlock, /#zen-loading-progress-bar::before/);
+  assert.doesNotMatch(css, /#zen-appcontent-wrapper::before/);
+  assert.doesNotMatch(css, /#zen-appcontent-wrapper::after/);
+  assert.doesNotMatch(css, /#tabbrowser-tabpanels::before/);
+  assert.doesNotMatch(css, /#tabbrowser-tabpanels::after/);
+  assert.doesNotMatch(css, /#tabbrowser-tabpanels > \.browserSidebarContainer:not\(\.zen-glance-overlay\)::before/);
+  assert.doesNotMatch(css, /#tabbrowser-tabpanels > \.browserSidebarContainer:not\(\.zen-glance-overlay\)::after/);
   assert.match(css, /max-width:\s*100%\s*!important/);
-  assert.match(css, /background:\s*var\(--zen-tab-header-foreground,\s*var\(--blended-addressbar-page-loadbar-foreground/);
-  assert.match(css, /#zen-appcontent-navbar-wrapper::before\s*\{[\s\S]*width 0\.7s ease-in-out/s);
-  assert.match(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend="true"\]\) > \.urlbar-background::before/);
-  assert.match(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend="true"\]\) > \.urlbar-background::after/);
-  assert.match(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend="true"\]\) > \.urlbar-background\s*\{[^}]*overflow:\s*hidden\s*!important/s);
-  assert.doesNotMatch(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend="true"\]\) > \.urlbar-background\s*\{[^}]*position:\s*relative/s);
-  assert.doesNotMatch(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend="true"\]\) > \.urlbar-background\s*\{[^}]*background:/s);
+  assert.match(css, /background:\s*var\(--blended-addressbar-dynamic-loadbar-color\)\s*!important/);
+  assert.doesNotMatch(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before,\s*#zen-appcontent-navbar-wrapper::after\s*\{[^}]*opacity:\s*var\(--blended-addressbar-loadbar-opacity/);
+  assert.doesNotMatch(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before,\s*#zen-appcontent-navbar-wrapper::after\s*\{[^}]*border-radius:/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before\s*\{[\s\S]*opacity:\s*var\(--blended-addressbar-loadbar-opacity,\s*0\.8\)\s*!important/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before\s*\{[\s\S]*border-radius:\s*0 var\(--blended-addressbar-loadbar-right-radius,\s*0px\) var\(--blended-addressbar-loadbar-right-radius,\s*0px\) 0\s*!important/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before,\s*#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*width 0\.7s ease-in-out/s);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*height:\s*24px\s*!important/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*opacity:\s*1\s*!important/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*background:\s*linear-gradient\(\s*to bottom,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-strong-mix,\s*27\.2%\),\s*transparent\) 0%,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-medium-mix,\s*14\.4%\),\s*transparent\) 36%,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-weak-mix,\s*5\.6%\),\s*transparent\) 68%,\s*transparent 100%\s*\)\s*!important/s);
+  assert.match(edgeModeBlock, /&:not\(:has\(\.tabbrowser-tab\[selected\]\[busy\]\)\) #zen-appcontent-navbar-wrapper::before,\s*&:not\(:has\(\.tabbrowser-tab\[selected\]\[busy\]\)\) #zen-appcontent-navbar-wrapper::after\s*\{[^}]*width:\s*0\s*!important;[^}]*opacity:\s*0\s*!important/s);
+  assert.match(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background::before/);
+  assert.match(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background::after/);
+  assert.doesNotMatch(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\)::after/);
+  assert.doesNotMatch(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend="true"\]\)/);
+  assert.match(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background\s*\{[^}]*overflow:\s*hidden\s*!important/s);
+  assert.match(urlbarGlowBackgroundBlock, /background-color:\s*transparent\s*!important/);
+  assert.match(urlbarGlowBackgroundBlock, /transition:\s*background-color 0\.2s ease-in-out\s*!important/);
+  assert.match(css, /&:is\(:has\(\.tabbrowser-tab\[selected\]\[busy\]\),\s*:has\(#zen-loading-progress-bar\[long-load\]\)\) #urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background\s*\{[^}]*background-color:\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-weak-mix,\s*5\.6%\),\s*transparent\)\s*!important/s);
+  assert.doesNotMatch(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background\s*\{[^}]*position:\s*relative/s);
+  assert.doesNotMatch(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background\s*\{[^}]*background:/s);
   assert.doesNotMatch(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\) \.urlbar-background\s*\{[^}]*overflow:\s*hidden/s);
-  assert.match(css, /height:\s*var\(--blended-addressbar-loadbar-height,\s*2px\)\s*!important/);
+  assert.match(urlbarGlowBeforeBlock, /top:\s*0\s*!important/);
+  assert.match(urlbarGlowBeforeBlock, /left:\s*0\s*!important/);
+  assert.match(urlbarGlowBeforeBlock, /right:\s*auto\s*!important/);
+  assert.match(urlbarGlowBeforeBlock, /bottom:\s*0\s*!important/);
+  assert.match(urlbarGlowBeforeBlock, /width:\s*var\(--blended-addressbar-loadbar-progress\)\s*!important/);
+  assert.match(urlbarGlowBeforeBlock, /min-width:\s*0\s*!important/);
+  assert.match(urlbarGlowBeforeBlock, /max-width:\s*100%\s*!important/);
+  assert.match(urlbarGlowBeforeBlock, /border-radius:\s*0 var\(--blended-addressbar-loadbar-right-radius,\s*0px\) var\(--blended-addressbar-loadbar-right-radius,\s*0px\) 0\s*!important/);
+  assert.doesNotMatch(urlbarGlowBeforeBlock, /inset:\s*0\s*!important/);
+  assert.match(urlbarGlowBeforeBlock, /linear-gradient\(\s*to top,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-strong-mix,\s*27\.2%\),\s*transparent\) 0%,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-medium-mix,\s*14\.4%\),\s*transparent\) 36%,\s*color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) var\(--blended-addressbar-loadbar-glow-weak-mix,\s*5\.6%\),\s*transparent\) 68%,\s*transparent 100%\s*\)/s);
+  assert.match(urlbarGlowBeforeBlock, /z-index:\s*0\s*!important/);
+  assert.match(urlbarGlowBeforeBlock, /width 0\.7s ease-in-out/);
+  assert.doesNotMatch(urlbarGlowBeforeBlock, /height:\s*24px\s*!important/);
+  assert.match(urlbarGlowAfterBlock, /top:\s*auto\s*!important/);
+  assert.match(urlbarGlowAfterBlock, /left:\s*0\s*!important/);
+  assert.match(urlbarGlowAfterBlock, /bottom:\s*0\s*!important/);
+  assert.match(urlbarGlowAfterBlock, /width:\s*var\(--blended-addressbar-loadbar-progress\)\s*!important/);
+  assert.match(urlbarGlowAfterBlock, /height:\s*var\(--blended-addressbar-loadbar-height,\s*2px\)\s*!important/);
+  assert.match(urlbarGlowAfterBlock, /border-radius:\s*0 var\(--blended-addressbar-loadbar-right-radius,\s*0px\) var\(--blended-addressbar-loadbar-right-radius,\s*0px\) 0\s*!important/);
+  assert.doesNotMatch(urlbarGlowAfterBlock, /top:\s*0\s*!important/);
+  assert.doesNotMatch(urlbarGlowAfterBlock, /bottom:\s*auto\s*!important/);
+  assert.doesNotMatch(urlbarGlowAfterBlock, /--blended-addressbar-urlbar-loadbar-edge-offset/);
+  assert.doesNotMatch(urlbarGlowAfterBlock, /max\(0px/);
+  assert.doesNotMatch(urlbarGlowAfterBlock, /height:\s*100%\s*!important/);
+  assert.match(urlbarGlowAfterBlock, /background:\s*var\(--blended-addressbar-dynamic-loadbar-color\)\s*!important/);
+  assert.match(urlbarGlowAfterBlock, /width 0\.7s ease-in-out/);
+  assert.doesNotMatch(urlbarGlowAfterBlock, /background-position:\s*0 0,\s*0 100%/);
+  assert.match(css, /&:is\(:has\(\.tabbrowser-tab\[selected\]\[busy\]\),\s*:has\(#zen-loading-progress-bar\[long-load\]\)\) #urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background::before/);
+  assert.match(css, /&:is\(:has\(\.tabbrowser-tab\[selected\]\[busy\]\),\s*:has\(#zen-loading-progress-bar\[long-load\]\)\) #urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background::before\s*\{[^}]*opacity:\s*1\s*!important/s);
+  assert.match(css, /&:is\(:has\(\.tabbrowser-tab\[selected\]\[busy\]\),\s*:has\(#zen-loading-progress-bar\[long-load\]\)\) #urlbar:not\(\[zen-floating-urlbar="true"\]\):not\(\[breakout-extend\]\) > \.urlbar-background::after/);
+  assert.doesNotMatch(css, /:root\[data-blended-addressbar-loadbar-mode="glow"\]\s*\{[\s\S]*:root:is\(:has\(\.tabbrowser-tab\[selected\]\[busy\]\),\s*:has\(#zen-loading-progress-bar\[long-load\]\)\) #urlbar/);
   assert.match(css, /border-radius:\s*0\s*!important/);
-  assert.match(css, /color-mix\(in srgb, var\(--blended-addressbar-loadbar-color, var\(--zen-primary-color\)\) 70%, white 30%\)/);
   assert.doesNotMatch(css, /white\s+\d+%,\s*transparent/);
-  assert.match(css, /color-mix\(in srgb, var\(--blended-addressbar-loadbar-color, var\(--zen-primary-color\)\) 96%, white 4%\)/);
+  assert.doesNotMatch(css, /color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) 40%,\s*transparent\)/);
+  assert.doesNotMatch(css, /color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) (?:34|18|7)%,\s*transparent\)/);
+  assert.doesNotMatch(css, /color-mix\(in srgb,\s*var\(--blended-addressbar-dynamic-loadbar-color\) 96%,\s*white 4%\)/);
+  assert.doesNotMatch(css, /data-blended-addressbar-loadbar-mode="edge"[\s\S]*--blended-addressbar-loadbar-static-color/);
+  assert.doesNotMatch(css, /data-blended-addressbar-loadbar-mode="glow"[\s\S]*--blended-addressbar-loadbar-static-color/);
   assert.doesNotMatch(css, /border-bottom:\s*var\(--blended-addressbar-loadbar-height/);
-  assert.match(css, /mask-image:\s*linear-gradient\(90deg,\s*black 0%,\s*black calc\(100% - 5rem\),\s*transparent 100%\)/);
-  assert.match(css, /:root:is\(:has\(\.tabbrowser-tab\[selected\]\[busy\]\),\s*:has\(#zen-loading-progress-bar\[long-load\]\)\)/);
+  assert.doesNotMatch(css, /mask-image:\s*linear-gradient\(to top,\s*black 0%,\s*black 72%,\s*transparent 100%\)/);
+  assert.doesNotMatch(css, /mask-image:\s*linear-gradient\(90deg/);
+  assert.match(css, /&:is\(:has\(\.tabbrowser-tab\[selected\]\[busy\]\),\s*:has\(#zen-loading-progress-bar\[long-load\]\)\)/);
   assert.match(css, /--blended-addressbar-loadbar-progress:\s*95%/);
   assert.doesNotMatch(css, /uc\.loadbar\.mode", "zen"/);
   assert.match(css, /:root\[inDOMFullscreen="true"\] #zen-loading-progress-bar/);
+  assert.match(css, /:root\[inDOMFullscreen="true"\] #zen-loading-progress-bar/);
   assert.doesNotMatch(css, /\.browserSidebarContainer\.deck-selected::before/);
   assert.match(prefs, /uc\.loadbar\.mode/);
-  assert.equal(loadbarModePreference.defaultValue, undefined);
-  assert.deepEqual(loadbarModePreference.options.map((option) => option.value), ['hidden', 'progress', 'glow', 'edge']);
-  assert.deepEqual(loadbarModePreference.options.map((option) => option.label), ['Hidden', 'Progress bar', 'URL bar glow', 'Window edge']);
+  assert.equal(loadbarModePreference.defaultValue, 'glow');
+  assert.deepEqual(loadbarModePreference.options.map((option) => option.value), ['default', 'progress', 'glow', 'edge']);
+  assert.deepEqual(loadbarModePreference.options.map((option) => option.label), ['Default', 'Progress bar', 'URL bar glow', 'Window edge']);
+  assert.equal(loadbarColorSourcePreference, undefined);
+  assert.equal(loadbarColorPreference.label, 'Fallback loadbar color');
+  assert.equal(loadbarColorPreference.defaultValue, 'var(--zen-primary-color)');
+  assert.equal(loadbarFocusColorPreference.label, 'Use focus color');
+  assert.equal(loadbarFocusColorPreference.type, 'checkbox');
+  assert.equal(loadbarFocusColorPreference.defaultValue, true);
+  assert.equal(prefsJson.find((pref) => pref.property === 'uc.loadbar.height').defaultValue, '2px');
+  assert.equal(prefsJson.find((pref) => pref.property === 'uc.loadbar.opacity').defaultValue, '80');
+  assert.doesNotMatch(prefs, /uc\.loadbar\.color-source/);
   assert.doesNotMatch(prefs, /uc\.loadbar\.position/);
   assert.match(readme, /uc\.loadbar\.mode/);
-  assert.match(readme, /Sine's built-in None keeps Zen's default loader/);
+  assert.match(readme, /Default keeps Zen's native loader/);
+  assert.match(readme, /uc\.loadbar\.color`: fallback loadbar color when no page or header color is available/);
+  assert.match(readme, /uc\.loadbar\.focus-color`: use the browser focus color for Progress bar, URL bar glow, and Window edge instead of the header foreground; enabled by default/);
+  assert.match(readme, /uc\.loadbar\.height`: loading bar thickness for all custom loadbar styles/);
+  assert.match(readme, /uc\.loadbar\.opacity`: loading bar body opacity and glow intensity for all custom loadbar styles/);
+  assert.match(readme, /uc\.loadbar\.roundedcorner`: enable right-side rounded corners for Progress bar, URL bar glow, and Window edge/);
+  assert.doesNotMatch(readme, /uc\.loadbar\.color-source/);
+  assert.doesNotMatch(readme, /Sine's built-in None/);
+  assert.doesNotMatch(readme, /choose Hidden/);
   assert.doesNotMatch(readme, /uc\.loadbar\.position/);
 });
 
@@ -861,4 +1028,43 @@ test('adaptive foreground feeds only Zen omnibox input text color', () => {
   assert.doesNotMatch(css, /#urlbar-input-container\s*\{[^}]*--input-color:\s*var\(--zen-tab-header-foreground/s);
   assert.doesNotMatch(css, /#urlbar\s*\{[^}]*--input-color:\s*var\(--zen-tab-header-foreground/s);
   assert.doesNotMatch(css, /#nav-bar-customization-target > :not\(#urlbar-container\),/);
+});
+
+test('bookmark toolbar popups keep readable menu colors and compact corners', () => {
+  const css = read('style.css');
+  const popupSelector = '#PersonalToolbar toolbarbutton.bookmark-item > menupopup.toolbar-menupopup[placespopup="true"]';
+  const popupBlock = cssRuleBlock(css, popupSelector);
+  const popupContentBlock = cssRuleBlock(css, `${popupSelector}::part(content)`);
+  const popupItemBlock = cssRuleBlock(css, `${popupSelector} :is(menu, menuitem, .menu-iconic, .menuitem-iconic, .bookmark-item)`);
+  const disabledPopupItemBlock = cssRuleBlock(css, `${popupSelector} :is(menu, menuitem, .bookmark-item):is([disabled], [disabled="true"])`);
+
+  assert.match(css, /--blended-addressbar-bookmark-popup-radius:\s*8px/);
+  assert.match(popupBlock, /--panel-background:\s*Menu\s*!important/);
+  assert.match(popupBlock, /--panel-color:\s*MenuText\s*!important/);
+  assert.match(popupBlock, /--panel-border-radius:\s*var\(--blended-addressbar-bookmark-popup-radius\)\s*!important/);
+  assert.match(popupContentBlock, /background:\s*Menu\s*!important/);
+  assert.match(popupContentBlock, /color:\s*MenuText\s*!important/);
+  assert.match(popupContentBlock, /border-radius:\s*var\(--blended-addressbar-bookmark-popup-radius\)\s*!important/);
+  assert.match(popupContentBlock, /overflow:\s*hidden\s*!important/);
+  assert.match(popupItemBlock, /color:\s*MenuText\s*!important/);
+  assert.match(popupItemBlock, /--toolbarbutton-icon-fill:\s*currentColor/);
+  assert.match(disabledPopupItemBlock, /color:\s*GrayText\s*!important/);
+  assert.doesNotMatch(popupBlock, /var\(--zen-tab-header-foreground/);
+});
+
+test('addressbar and bookmarks separator can be collapsed to one visible line', () => {
+  const css = read('style.css');
+  const prefs = read('preferences.json');
+  const readme = read('README.md');
+  const prefsJson = JSON.parse(prefs);
+  const separatorPreference = prefsJson.find((pref) => pref.property === 'uc.blended-addressbar.addressbar-bookmarks-separator.disabled');
+
+  assert.equal(separatorPreference.type, 'checkbox');
+  assert.equal(separatorPreference.label, 'Remove addressbar/bookmarks separator');
+  assert.match(css, /--blended-addressbar-toolbar-separator-shadow:\s*0 -1px 0 0 inset rgba\(128,\s*128,\s*128,\s*0\.09\)/);
+  assert.match(css, /#nav-bar\s*\{[\s\S]*box-shadow:\s*var\(--blended-addressbar-toolbar-separator-shadow\)/);
+  assert.match(css, /#nav-bar:not\(\[hidden\]\):not\(\[collapsed="true"\]\) \+ #PersonalToolbar:not\(\[hidden\]\):not\(\[collapsed="true"\]\)\s*\{[\s\S]*box-shadow:\s*var\(--blended-addressbar-toolbar-separator-shadow\)/);
+  assert.match(css, /@media \(-moz-bool-pref:\s*"uc\.blended-addressbar\.addressbar-bookmarks-separator\.disabled"\)\s*\{[\s\S]*#nav-bar:not\(\[hidden\]\):not\(\[collapsed="true"\]\):has\(\+ #PersonalToolbar:not\(\[hidden\]\):not\(\[collapsed="true"\]\)\)\s*\{[\s\S]*box-shadow:\s*none\s*!important/s);
+  assert.doesNotMatch(css, /@media \(-moz-bool-pref:\s*"uc\.blended-addressbar\.addressbar-bookmarks-separator\.disabled"\)\s*\{[\s\S]*#nav-bar:not\(\[hidden\]\):not\(\[collapsed="true"\]\) \+ #PersonalToolbar:not\(\[hidden\]\):not\(\[collapsed="true"\]\)\s*\{[\s\S]*box-shadow:\s*none\s*!important/s);
+  assert.match(readme, /uc\.blended-addressbar\.addressbar-bookmarks-separator\.disabled/);
 });

--- a/tests/native-theme.test.js
+++ b/tests/native-theme.test.js
@@ -596,6 +596,8 @@ test('loadbar modes customize the native Zen loading progress element', () => {
   assert.doesNotMatch(css, /--blended-addressbar-loadbar-progress:\s*max\(var\(--blended-addressbar-loadbar-progress\)/);
   assert.match(css, /--blended-addressbar-dynamic-loadbar-color:\s*var\(--zen-tab-header-foreground,\s*var\(--blended-addressbar-page-loadbar-foreground,\s*var\(--blended-addressbar-loadbar-static-color,\s*var\(--zen-primary-color\)\)\)\)/);
   assert.match(css, /--blended-addressbar-loadbar-right-radius:\s*0px/);
+  assert.match(css, /--blended-addressbar-loadbar-edge-top-offset:\s*0px/);
+  assert.match(css, /@media \(-moz-bool-pref: "uc\.blended-addressbar\.frame-padding\.disabled"\)\s*\{[\s\S]*--blended-addressbar-loadbar-edge-top-offset:\s*var\(--blended-addressbar-loadbar-height,\s*2px\)/);
   assert.match(css, /@media \(-moz-bool-pref: "uc\.loadbar\.roundedcorner"\)\s*\{[\s\S]*--blended-addressbar-loadbar-right-radius:\s*var\(--blended-addressbar-loadbar-height,\s*2px\)/);
   assert.match(css, /:root\[data-blended-addressbar-loadbar-focus-color="true"\]\s*\{[^}]*--blended-addressbar-dynamic-loadbar-color:\s*var\(--zen-primary-color\)/);
   assert.match(css, /--blended-addressbar-loadbar-glow-strong-mix:\s*27\.2%/);
@@ -617,8 +619,8 @@ test('loadbar modes customize the native Zen loading progress element', () => {
   assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before,\s*#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*position:\s*absolute\s*!important/);
   assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before,\s*#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*width:\s*var\(--blended-addressbar-loadbar-progress\)\s*!important/);
   assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before,\s*#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*max-width:\s*100%\s*!important/);
-  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before\s*\{[\s\S]*top:\s*0\s*!important/);
-  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*top:\s*var\(--blended-addressbar-loadbar-height,\s*2px\)\s*!important/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::before\s*\{[\s\S]*top:\s*var\(--blended-addressbar-loadbar-edge-top-offset,\s*0px\)\s*!important/);
+  assert.match(edgeModeBlock, /#zen-appcontent-navbar-wrapper::after\s*\{[\s\S]*top:\s*calc\(var\(--blended-addressbar-loadbar-edge-top-offset,\s*0px\) \+ var\(--blended-addressbar-loadbar-height,\s*2px\)\)\s*!important/);
   assert.doesNotMatch(edgeModeBlock, /#zen-loading-progress-bar::before/);
   assert.doesNotMatch(css, /#zen-appcontent-wrapper::before/);
   assert.doesNotMatch(css, /#zen-appcontent-wrapper::after/);

--- a/theme.json
+++ b/theme.json
@@ -3,9 +3,9 @@
   "name": "Blended Addressbar",
   "description": "A page-aware addressbar that blends Zen chrome with the active website.",
   "author": "Kostiantyn Kugot",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "ai": "partial",
-  "updatedAt": "2026-06-05",
+  "updatedAt": "2026-06-19",
   "tags": [
     "addressbar",
     "urlbar",


### PR DESCRIPTION
## Summary
- Bump Blended Addressbar to 1.4.0 and update marketplace metadata.
- Rework loadbar modes so Progress bar, URL bar glow, and Window edge share color, opacity, glow intensity, thickness, radius, and width transition behavior.
- Make URL bar glow the default custom loadbar style and default loadbar opacity to 100%.
- Add the focus-color preference.
- Keep the Window edge loadbar body visible when browser frame padding is disabled.
- Keep shadow as an optional drop-shadow for Progress bar and Window edge body styles; URL bar glow remains controlled by opacity/glow intensity.
- Add the addressbar/bookmarks separator preference and bookmark popup readability fixes.
- Remove obsolete selector-rule and legacy loadbar color-source handling.

## Tests
- node --test tests/native-theme.test.js