### PR TITLE
Fix press-and-hold menus closing instantly: exclude toolbar buttons from window-drag region

### DIFF
--- a/style.css
+++ b/style.css
@@ -123,6 +123,17 @@
             --toolbar-field-color: var(--zen-tab-header-foreground, currentColor);
         }
 
+        /* Interactive children must stay clickable, not draggable: on a drag
+           region, press-and-hold menus (back/forward session history, bookmark
+           folders) roll up the moment the first pixel of cursor drift starts
+           moving the window, and a click with slight drift drags the window
+           instead of clicking. Spacers and the empty strip remain draggable. */
+        #nav-bar-customization-target > :not(#urlbar-container):not(#urlbar[zen-floating-urlbar="true"]):is(toolbarbutton, toolbaritem),
+        #PersonalToolbar :is(toolbarbutton, .bookmark-item),
+        #PanelUI-button:is(toolbaritem, toolbarbutton) {
+            -moz-window-dragging: no-drag;
+        }
+
         :is(
             #nav-bar-customization-target > :not(#urlbar-container):not(#urlbar[zen-floating-urlbar="true"]),
             #nav-bar-customization-target > :not(#urlbar-container):not(#urlbar[zen-floating-urlbar="true"]) :is(toolbarbutton, .toolbarbutton-1, .toolbarbutton-icon, .toolbarbutton-text, .urlbar-icon),


### PR DESCRIPTION
## Problem

Click-and-hold on the back/forward buttons opens the session history menu, which then closes by itself almost immediately. Same mechanism affects bookmark folder menus on the personal toolbar. Reproduced on macOS.

## Cause

`style.css` applies `-moz-window-dragging: drag` to the nav-bar children themselves (`#nav-bar-customization-target > :not(#urlbar-container)...`), to `#PersonalToolbar`, and to `#PanelUI-button`. That makes each button a window-drag region. During a press-and-hold, the hold timer opens the menupopup, then the first pixel of cursor drift starts a native window drag, and Gecko rolls up any open popup as soon as the window moves. Easy to confirm: hold the back button and move the cursor, the whole window follows.

Side effect of the same rule: a normal click with slight cursor drift can drag the window instead of registering the click.

Right-click history on the back button is unaffected (window drag is left-button only), which is what narrowed this down.

## Fix

One exception rule after the drag rule: `-moz-window-dragging: no-drag` on interactive children (toolbarbuttons/toolbaritems in the nav-bar target, `#PersonalToolbar` buttons and bookmark items, `#PanelUI-button`). Selector repeats the original `:not()` chain so it wins on specificity without `!important`. Spacers and the empty header strip remain draggable, so moving the window by its header still works.

## Validation

- Cause confirmed manually on Zen (macOS): holding the back button and moving the cursor drags the whole window while the menu dies; right-click history menu on the same button survives.
- Fix verified with an equivalent local no-drag override in the installed profile; will report back after running this exact patch.
- `node tests/native-theme.test.js`: 42 pass, 0 fail.