### PR TITLE
Fix adaptive colors for sidebar and copy-link icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.4.1 - 2026-08-09
 
-- Fixed adaptive foreground and opacity for the sidebar toggle and copy-link icons in Zen Only Sidebar and compact modes.
+- Fixed adaptive foreground and opacity for Zen Only Sidebar, compact-mode, site-properties, copy-link, and macOS window-control icons.
 
 ## 1.4.0 - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.1 - 2026-08-09
+
+- Fixed adaptive foreground and opacity for the sidebar toggle and copy-link icons in Zen Only Sidebar and compact modes.
+
 ## 1.4.0 - 2026-06-19
 
 - Made URL bar glow the default custom loadbar style while keeping a Default option for Zen's native loader.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.4.1 - 2026-08-09
 
-- Fixed adaptive foreground and opacity for Zen Only Sidebar, compact-mode, site-properties, copy-link, and macOS window-control icons.
+- Fixed adaptive foreground and opacity for Zen Only Sidebar, compact-mode, site-properties, copy-link, and macOS window-control icons; non-boost site-properties now follow light/dark page headers while Zen Boost keeps its native contrast.
 
 ## 1.4.0 - 2026-06-19
 

--- a/style.css
+++ b/style.css
@@ -303,10 +303,18 @@
 
     /* Zen moves these controls between the titlebar and nav-bar in Only Sidebar mode. */
     :is(
-        #titlebar > #zen-sidebar-top-buttons #zen-expand-sidebar-button,
-        #nav-bar > #zen-sidebar-top-buttons #zen-expand-sidebar-button,
-        #titlebar > #zen-sidebar-top-buttons #zen-expand-sidebar-button image,
-        #nav-bar > #zen-sidebar-top-buttons #zen-expand-sidebar-button image,
+        :is(#titlebar > #zen-sidebar-top-buttons, #nav-bar > #zen-sidebar-top-buttons) :is(
+            #zen-toggle-compact-mode,
+            #history-panelmenu,
+            #bookmarks-menu-button,
+            #zen-expand-sidebar-button
+        ),
+        :is(#titlebar > #zen-sidebar-top-buttons, #nav-bar > #zen-sidebar-top-buttons) :is(
+            #zen-toggle-compact-mode,
+            #history-panelmenu,
+            #bookmarks-menu-button,
+            #zen-expand-sidebar-button
+        ) image,
         #urlbar:not([zen-floating-urlbar="true"]):not([focused]):not([open]):not([breakout-extend="true"]) #zen-copy-url-button,
         #urlbar:not([zen-floating-urlbar="true"]):not([focused]):not([open]):not([breakout-extend="true"]) #zen-copy-url-button image
     ) {

--- a/style.css
+++ b/style.css
@@ -301,6 +301,15 @@
         --urlbar-icon-fill-opacity: 1;
     }
 
+    /* Zen moves the macOS window controls between the sidebar and addressbar. */
+    #zen-sidebar-top-buttons .titlebar-buttonbox-container,
+    #zen-appcontent-navbar-wrapper .titlebar-buttonbox-container {
+        color: var(--zen-tab-header-foreground, inherit) !important;
+        transition: color var(--blended-addressbar-color-transition);
+        --toolbox-textcolor: var(--zen-tab-header-foreground, currentColor);
+        --zen-toolbar-element-bg: color-mix(in srgb, currentColor 14%, transparent) !important;
+    }
+
     /* Zen moves these controls between the titlebar and nav-bar in Only Sidebar mode. */
     :is(
         :is(#titlebar > #zen-sidebar-top-buttons, #nav-bar > #zen-sidebar-top-buttons) :is(

--- a/style.css
+++ b/style.css
@@ -301,6 +301,17 @@
         --urlbar-icon-fill-opacity: 1;
     }
 
+    #zen-site-data-icon-button:not([boosting]),
+    #zen-site-data-icon-button:not([boosting]) image {
+        color: var(--zen-tab-header-foreground, currentColor) !important;
+        fill: currentColor !important;
+        fill-opacity: 1 !important;
+        stroke: currentColor !important;
+        stroke-opacity: 1 !important;
+        --toolbarbutton-icon-fill: currentColor !important;
+        --urlbar-icon-fill-opacity: 1 !important;
+    }
+
     /* Zen moves the macOS window controls between the sidebar and addressbar. */
     #zen-sidebar-top-buttons .titlebar-buttonbox-container {
         color: var(--zen-sidebar-themed-icon-fill, var(--toolbox-textcolor, currentColor)) !important;

--- a/style.css
+++ b/style.css
@@ -302,7 +302,12 @@
     }
 
     /* Zen moves the macOS window controls between the sidebar and addressbar. */
-    #zen-sidebar-top-buttons .titlebar-buttonbox-container,
+    #zen-sidebar-top-buttons .titlebar-buttonbox-container {
+        color: var(--zen-sidebar-themed-icon-fill, var(--toolbox-textcolor, currentColor)) !important;
+        transition: color var(--blended-addressbar-color-transition);
+        --zen-toolbar-element-bg: color-mix(in srgb, currentColor 14%, transparent) !important;
+    }
+
     #zen-appcontent-navbar-wrapper .titlebar-buttonbox-container {
         color: var(--zen-tab-header-foreground, inherit) !important;
         transition: color var(--blended-addressbar-color-transition);

--- a/style.css
+++ b/style.css
@@ -10,8 +10,8 @@
         0 4px 16px rgba(0, 0, 0, 0.14),
         0 1px 4px rgba(0, 0, 0, 0.12);
     --blended-addressbar-frame-shadow-minimal:
-        0 0 0 1px rgba(0, 0, 0, 0.08),
-        0 1px 2px rgba(0, 0, 0, 0.05);
+        0 0 0 1px rgba(0, 0, 0, 0.10),
+        0 2px 8px rgba(0, 0, 0, 0.10);
     --blended-addressbar-frame-shadow-medium:
         0 5px 12px rgba(0, 0, 0, 0.10),
         0 1px 2px rgba(0, 0, 0, 0.10);
@@ -35,8 +35,8 @@
             0 6px 18px rgba(0, 0, 0, 0.34),
             0 1px 5px rgba(0, 0, 0, 0.30);
         --blended-addressbar-frame-shadow-minimal:
-            0 0 0 1px rgba(255, 255, 255, 0.08),
-            0 1px 2px rgba(0, 0, 0, 0.16);
+            0 0 0 1px rgba(255, 255, 255, 0.10),
+            0 2px 8px rgba(0, 0, 0, 0.24);
         --blended-addressbar-frame-shadow-medium:
             0 6px 14px rgba(0, 0, 0, 0.30),
             0 1px 3px rgba(0, 0, 0, 0.28);
@@ -45,8 +45,8 @@
 
 :root:not([zen-should-be-dark-mode]) {
     --blended-addressbar-frame-shadow-minimal:
-        0 0 0 1px rgba(0, 0, 0, 0.08),
-        0 1px 2px rgba(0, 0, 0, 0.05);
+        0 0 0 1px rgba(0, 0, 0, 0.10),
+        0 2px 8px rgba(0, 0, 0, 0.10);
 }
 
 /* URL bar */
@@ -83,11 +83,24 @@
         }
     }
 
-    &[inDOMFullscreen="true"] {
+    &:is([inDOMFullscreen="true"], [inFullscreen="true"], [macOSNativeFullscreen], [zen-no-padding="true"]) {
         #zen-appcontent-wrapper {
             margin: 0 !important;
             border-radius: 0 !important;
-            box-shadow: none;
+            box-shadow: none !important;
+        }
+
+        #nav-bar,
+        #nav-bar:not([hidden]):not([collapsed="true"]) + #PersonalToolbar:not([hidden]):not([collapsed="true"]) {
+            box-shadow: none !important;
+        }
+
+        #tabbrowser-tabpanels > .browserSidebarContainer:not(.zen-glance-overlay) {
+            --blended-addressbar-split-radius-top-left: 0px;
+            --blended-addressbar-split-radius-top-right: 0px;
+            --blended-addressbar-split-radius-bottom-right: 0px;
+            --blended-addressbar-split-radius-bottom-left: 0px;
+            --zen-native-inner-radius: 0 0 0 0 !important;
         }
     }
 
@@ -137,8 +150,8 @@
         :is(
             #nav-bar-customization-target > :not(#urlbar-container):not(#urlbar[zen-floating-urlbar="true"]),
             #nav-bar-customization-target > :not(#urlbar-container):not(#urlbar[zen-floating-urlbar="true"]) :is(toolbarbutton, .toolbarbutton-1, .toolbarbutton-icon, .toolbarbutton-text, .urlbar-icon),
-            #urlbar:not([zen-floating-urlbar="true"]) #urlbar-input-container :is(.urlbar-page-action, .identity-box-button, .urlbar-icon),
-            #urlbar:not([zen-floating-urlbar="true"]) #urlbar-input-container :is(.urlbar-page-action, .identity-box-button) :is(.toolbarbutton-icon, .urlbar-icon),
+            #urlbar:not([zen-floating-urlbar="true"]) #urlbar-input-container :is(#identity-box, #trust-icon-container, #tracking-protection-icon-container, #zen-site-data-icon-button, .urlbar-page-action, .identity-box-button, .urlbar-icon),
+            #urlbar:not([zen-floating-urlbar="true"]) #urlbar-input-container :is(#identity-box, #trust-icon-container, #tracking-protection-icon-container, #zen-site-data-icon-button, .urlbar-page-action, .identity-box-button) :is(.toolbarbutton-icon, .urlbar-icon, image),
             #personal-bookmarks,
             #personal-bookmarks.browser-toolbar,
             #PersonalToolbar :is(#personal-bookmarks, .browser-toolbar),
@@ -152,12 +165,15 @@
         ) {
             color: var(--zen-tab-header-foreground, inherit) !important;
             fill: currentColor !important;
+            fill-opacity: 1 !important;
             stroke: currentColor !important;
+            stroke-opacity: 1 !important;
             transition: color var(--blended-addressbar-color-transition), fill var(--blended-addressbar-color-transition), stroke var(--blended-addressbar-color-transition);
             --toolbox-textcolor: var(--zen-tab-header-foreground, currentColor);
-            --toolbarbutton-icon-fill: var(--zen-tab-header-foreground, currentColor);
+            --toolbarbutton-icon-fill: currentColor !important;
             --toolbar-color: var(--zen-tab-header-foreground, currentColor);
             --toolbar-field-color: var(--zen-tab-header-foreground, currentColor);
+            --urlbar-icon-fill-opacity: 1;
         }
 
         #urlbar:not([zen-floating-urlbar="true"]) #zen-site-data-icon-button[boosting] image {
@@ -255,6 +271,52 @@
             background-color: SelectedItem !important;
             color: SelectedItemText !important;
         }
+    }
+
+    #navigator-toolbox:not([tabs-hidden]) :is(
+        #nav-bar-customization-target > :not(#urlbar-container):not(#urlbar[zen-floating-urlbar="true"]),
+        #nav-bar-customization-target > :not(#urlbar-container):not(#urlbar[zen-floating-urlbar="true"]) :is(toolbarbutton, .toolbarbutton-1, .toolbarbutton-icon, .toolbarbutton-text, .urlbar-icon, image),
+        #urlbar:not([zen-floating-urlbar="true"]):not([focused]):not([open]):not([breakout-extend="true"]) :is(#identity-box, #zen-site-data-icon-button, #zen-copy-url-button, .urlbar-page-action, .identity-box-button, .urlbar-icon),
+        #urlbar:not([zen-floating-urlbar="true"]):not([focused]):not([open]):not([breakout-extend="true"]) :is(#identity-box, #zen-site-data-icon-button, #zen-copy-url-button, .urlbar-page-action, .identity-box-button) :is(.urlbar-icon, image),
+        #PanelUI-button,
+        #PanelUI-button :is(toolbarbutton, .toolbarbutton-1, .toolbarbutton-icon, image)
+    ) {
+        color: var(--zen-tab-header-foreground, inherit) !important;
+        fill: currentColor !important;
+        fill-opacity: 1 !important;
+        stroke: currentColor !important;
+        stroke-opacity: 1 !important;
+        --toolbarbutton-icon-fill: currentColor !important;
+        --urlbar-icon-fill-opacity: 1;
+    }
+
+    #navigator-toolbox:not([tabs-hidden]) #zen-site-data-icon-button.identity-box-button,
+    #navigator-toolbox:not([tabs-hidden]) #zen-site-data-icon-button.identity-box-button > image {
+        color: var(--zen-tab-header-foreground, inherit) !important;
+        fill: currentColor !important;
+        fill-opacity: 1 !important;
+        stroke: currentColor !important;
+        stroke-opacity: 1 !important;
+        --toolbarbutton-icon-fill: currentColor !important;
+        --urlbar-icon-fill-opacity: 1;
+    }
+
+    /* Zen moves these controls between the titlebar and nav-bar in Only Sidebar mode. */
+    :is(
+        #titlebar > #zen-sidebar-top-buttons #zen-expand-sidebar-button,
+        #nav-bar > #zen-sidebar-top-buttons #zen-expand-sidebar-button,
+        #titlebar > #zen-sidebar-top-buttons #zen-expand-sidebar-button image,
+        #nav-bar > #zen-sidebar-top-buttons #zen-expand-sidebar-button image,
+        #urlbar:not([zen-floating-urlbar="true"]):not([focused]):not([open]):not([breakout-extend="true"]) #zen-copy-url-button,
+        #urlbar:not([zen-floating-urlbar="true"]):not([focused]):not([open]):not([breakout-extend="true"]) #zen-copy-url-button image
+    ) {
+        color: var(--zen-tab-header-foreground, inherit) !important;
+        fill: currentColor !important;
+        fill-opacity: 1 !important;
+        stroke: currentColor !important;
+        stroke-opacity: 1 !important;
+        --toolbarbutton-icon-fill: currentColor !important;
+        --urlbar-icon-fill-opacity: 1 !important;
     }
 
     #nav-bar {

--- a/styles/header-chrome.css
+++ b/styles/header-chrome.css
@@ -29,7 +29,8 @@
         --toolbar-field-color: var(--blended-addressbar-header-chrome-foreground);
     }
 
-    #navigator-toolbox[tabs-hidden] :is(.urlbar-icon, .identity-box-button, .urlbar-page-action) {
+    #navigator-toolbox[tabs-hidden] :is(.urlbar-icon, .identity-box-button, .urlbar-page-action, #zen-site-data-icon-button),
+    #navigator-toolbox[tabs-hidden] #zen-site-data-icon-button image {
         color: var(--blended-addressbar-header-chrome-foreground) !important;
         fill: currentColor !important;
         fill-opacity: 0.6 !important;

--- a/tests/native-theme.test.js
+++ b/tests/native-theme.test.js
@@ -405,10 +405,14 @@ test('window controls follow adaptive header colors in sidebar and addressbar pl
     assert.match(selector, /\.titlebar-buttonbox-container/);
   }
 
-  const trafficBlock = cssRuleBlock(css, '#zen-appcontent-navbar-wrapper .titlebar-buttonbox-container');
-  assert.match(trafficBlock, /color:\s*var\(--zen-tab-header-foreground,\s*inherit\)\s*!important/);
-  assert.match(trafficBlock, /--toolbox-textcolor:\s*var\(--zen-tab-header-foreground,\s*currentColor\)/);
-  assert.match(trafficBlock, /--zen-toolbar-element-bg:\s*color-mix\(in srgb,\s*currentColor\s*14%,\s*transparent\)\s*!important/);
+  const addressbarTrafficBlock = cssRuleBlock(css, '#zen-appcontent-navbar-wrapper .titlebar-buttonbox-container');
+  const sidebarTrafficBlock = cssRuleBlock(css, '#zen-sidebar-top-buttons .titlebar-buttonbox-container');
+  assert.match(addressbarTrafficBlock, /color:\s*var\(--zen-tab-header-foreground,\s*inherit\)\s*!important/);
+  assert.match(addressbarTrafficBlock, /--toolbox-textcolor:\s*var\(--zen-tab-header-foreground,\s*currentColor\)/);
+  assert.match(addressbarTrafficBlock, /--zen-toolbar-element-bg:\s*color-mix\(in srgb,\s*currentColor\s*14%,\s*transparent\)\s*!important/);
+  assert.match(sidebarTrafficBlock, /color:\s*var\(--zen-sidebar-themed-icon-fill,\s*var\(--toolbox-textcolor,\s*currentColor\)\)\s*!important/);
+  assert.doesNotMatch(sidebarTrafficBlock, /--zen-tab-header-foreground/);
+  assert.match(sidebarTrafficBlock, /--zen-toolbar-element-bg:\s*color-mix\(in srgb,\s*currentColor\s*14%,\s*transparent\)\s*!important/);
 });
 
 test('hidden tab chrome styling lives in a focused imported stylesheet', () => {

--- a/tests/native-theme.test.js
+++ b/tests/native-theme.test.js
@@ -375,15 +375,19 @@ test('hidden tab sidebar toolbar icons use the softer addressbar chrome foregrou
   assert.doesNotMatch(headerCss, /&:has\(\[zen-compact-mode="true"\]\)\s+#zen-appcontent-navbar-wrapper/);
 });
 
-test('adaptive chrome colors cover Zen moved sidebar and copy URL icons', () => {
+test('adaptive chrome colors cover Zen moved sidebar toolbar and copy URL icons', () => {
   const css = readStyleWithImports();
 
   const titlebarSidebarSelector = cssSelectorPrelude(css, '#titlebar > #zen-sidebar-top-buttons');
   const navBarSidebarSelector = cssSelectorPrelude(css, '#nav-bar > #zen-sidebar-top-buttons');
   const copyUrlIconBlock = cssRuleBlock(css, '#zen-copy-url-button image');
 
-  assert.match(titlebarSidebarSelector, /#zen-expand-sidebar-button/);
-  assert.match(navBarSidebarSelector, /#zen-expand-sidebar-button/);
+  assert.match(titlebarSidebarSelector, /#zen-sidebar-top-buttons\)\s*:is\(/);
+  assert.match(navBarSidebarSelector, /#zen-sidebar-top-buttons\)\s*:is\(/);
+  for (const buttonId of ['#zen-toggle-compact-mode', '#history-panelmenu', '#bookmarks-menu-button']) {
+    assert.match(titlebarSidebarSelector, new RegExp(buttonId.slice(1)));
+    assert.match(navBarSidebarSelector, new RegExp(buttonId.slice(1)));
+  }
   assert.match(copyUrlIconBlock, /color:\s*var\(--zen-tab-header-foreground,\s*(?:inherit|currentColor)\)\s*!important/);
   assert.match(copyUrlIconBlock, /fill:\s*currentColor\s*!important/);
   assert.match(copyUrlIconBlock, /fill-opacity:\s*1\s*!important/);

--- a/tests/native-theme.test.js
+++ b/tests/native-theme.test.js
@@ -1089,6 +1089,21 @@ test('adaptive foreground feeds only Zen omnibox input text color', () => {
   assert.doesNotMatch(css, /#nav-bar-customization-target > :not\(#urlbar-container\),/);
 });
 
+test('non-boost site properties icon follows adaptive header colors while boost keeps native coloring', () => {
+  const css = readStyleWithImports();
+  const nonBoostButtonBlock = cssRuleBlock(css, '#zen-site-data-icon-button:not([boosting])');
+
+  assert.match(nonBoostButtonBlock, /color:\s*var\(--zen-tab-header-foreground,\s*currentColor\)\s*!important/);
+  assert.match(nonBoostButtonBlock, /fill:\s*currentColor\s*!important/);
+  assert.match(nonBoostButtonBlock, /fill-opacity:\s*1\s*!important/);
+  assert.match(nonBoostButtonBlock, /stroke:\s*currentColor\s*!important/);
+  assert.match(nonBoostButtonBlock, /stroke-opacity:\s*1\s*!important/);
+  assert.match(nonBoostButtonBlock, /--toolbarbutton-icon-fill:\s*currentColor\s*!important/);
+  assert.match(nonBoostButtonBlock, /--urlbar-icon-fill-opacity:\s*1\s*!important/);
+  assert.match(css, /#zen-site-data-icon-button\[boosting\] image/);
+  assert.doesNotMatch(nonBoostButtonBlock, /\[boosting\]/);
+});
+
 test('bookmark toolbar popups keep readable menu colors and compact corners', () => {
   const css = read('style.css');
   const popupSelector = '#PersonalToolbar toolbarbutton.bookmark-item > menupopup.toolbar-menupopup[placespopup="true"]';

--- a/tests/native-theme.test.js
+++ b/tests/native-theme.test.js
@@ -336,9 +336,10 @@ test('frame gap, remove-padding checkbox, and inner radius settings coexist', ()
 test('DOM fullscreen removes the framed browser surface', () => {
   const css = read('style.css');
 
-  assert.match(css, /&\[inDOMFullscreen="true"\]\s*\{\s*#zen-appcontent-wrapper\s*\{[^}]*margin:\s*0\s*!important/s);
-  assert.match(css, /&\[inDOMFullscreen="true"\]\s*\{\s*#zen-appcontent-wrapper\s*\{[^}]*border-radius:\s*0\s*!important/s);
-  assert.match(css, /&\[inDOMFullscreen="true"\]\s*\{\s*#zen-appcontent-wrapper\s*\{[^}]*box-shadow:\s*none/s);
+  assert.match(css, /&:is\(\[inDOMFullscreen="true"\],\s*\[inFullscreen="true"\],\s*\[macOSNativeFullscreen\],\s*\[zen-no-padding="true"\]\)/);
+  assert.match(css, /&:is\([^)]*\)\s*\{[\s\S]*#zen-appcontent-wrapper\s*\{[^}]*margin:\s*0\s*!important[^}]*border-radius:\s*0\s*!important[^}]*box-shadow:\s*none\s*!important/s);
+  assert.match(css, /&:is\([^)]*\)\s*\{[\s\S]*#nav-bar,\s*[\r\n]+\s*#nav-bar:not\(\[hidden\]\):not\(\[collapsed="true"\]\) \+ #PersonalToolbar:not\(\[hidden\]\):not\(\[collapsed="true"\]\)\s*\{[^}]*box-shadow:\s*none\s*!important/s);
+  assert.match(css, /&:is\([^)]*\)\s*\{[\s\S]*#tabbrowser-tabpanels > \.browserSidebarContainer:not\(\.zen-glance-overlay\)\s*\{[^}]*--zen-native-inner-radius:\s*0 0 0 0\s*!important/s);
 });
 
 test('expanded sidebar toolbox keeps chrome icons vertically aligned', () => {
@@ -374,6 +375,21 @@ test('hidden tab sidebar toolbar icons use the softer addressbar chrome foregrou
   assert.doesNotMatch(headerCss, /&:has\(\[zen-compact-mode="true"\]\)\s+#zen-appcontent-navbar-wrapper/);
 });
 
+test('adaptive chrome colors cover Zen moved sidebar and copy URL icons', () => {
+  const css = readStyleWithImports();
+
+  const titlebarSidebarSelector = cssSelectorPrelude(css, '#titlebar > #zen-sidebar-top-buttons');
+  const navBarSidebarSelector = cssSelectorPrelude(css, '#nav-bar > #zen-sidebar-top-buttons');
+  const copyUrlIconBlock = cssRuleBlock(css, '#zen-copy-url-button image');
+
+  assert.match(titlebarSidebarSelector, /#zen-expand-sidebar-button/);
+  assert.match(navBarSidebarSelector, /#zen-expand-sidebar-button/);
+  assert.match(copyUrlIconBlock, /color:\s*var\(--zen-tab-header-foreground,\s*(?:inherit|currentColor)\)\s*!important/);
+  assert.match(copyUrlIconBlock, /fill:\s*currentColor\s*!important/);
+  assert.match(copyUrlIconBlock, /fill-opacity:\s*1\s*!important/);
+  assert.match(copyUrlIconBlock, /--toolbarbutton-icon-fill:\s*currentColor\s*!important/);
+});
+
 test('hidden tab chrome styling lives in a focused imported stylesheet', () => {
   const css = read('style.css');
   const headerCss = read('styles/header-chrome.css');
@@ -404,7 +420,7 @@ test('frame shadow is selected through constrained dropdown presets', () => {
   assert.match(script, /data-blended-addressbar-frame-shadow/);
   assert.match(css, /--blended-addressbar-frame-shadow-standard:/);
   assert.match(css, /--blended-addressbar-frame-shadow-minimal:/);
-  assert.match(css, /:root:not\(\[zen-should-be-dark-mode\]\)\s*\{[^}]*--blended-addressbar-frame-shadow-minimal:\s*0 0 0 1px rgba\(0,\s*0,\s*0,\s*0\.08\),\s*0 1px 2px rgba\(0,\s*0,\s*0,\s*0\.05\)/s);
+  assert.match(css, /:root:not\(\[zen-should-be-dark-mode\]\)\s*\{[^}]*--blended-addressbar-frame-shadow-minimal:\s*0 0 0 1px rgba\(0,\s*0,\s*0,\s*0\.10\),\s*0 2px 8px rgba\(0,\s*0,\s*0,\s*0\.10\)/s);
   assert.match(css, /--blended-addressbar-frame-shadow-medium:/);
   assert.doesNotMatch(css, /\[data-blended-addressbar-frame-shadow="none"\]/);
   assert.doesNotMatch(css, /--blended-addressbar-frame-shadow:\s*none/);
@@ -1013,9 +1029,25 @@ test('adaptive foreground feeds only Zen omnibox input text color', () => {
   assert.match(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\) #urlbar-input::selection\s*\{[^}]*background-color:\s*SelectedItem\s*!important[^}]*color:\s*SelectedItemText\s*!important/s);
   assert.match(css, /--blended-addressbar-header-muted-foreground:\s*color-mix\(in srgb,\s*var\(--zen-tab-header-foreground,\s*currentColor\)\s*42%,\s*transparent\)/);
   const urlbarIconSelector = cssSelectorPrelude(css, '#urlbar:not([zen-floating-urlbar="true"]) #urlbar-input-container');
+  const urlbarIconBlock = cssRuleBlock(css, '#urlbar:not([zen-floating-urlbar="true"]) #urlbar-input-container :is(#identity-box');
+  const unscopedChromeIconSelector = cssSelectorPrelude(css, '#navigator-toolbox:not([tabs-hidden]) :is(');
+  const unscopedChromeIconBlock = cssRuleBlock(css, '#navigator-toolbox:not([tabs-hidden]) :is(');
+  const zenSiteDataButtonBlock = cssRuleBlock(css, '#navigator-toolbox:not([tabs-hidden]) #zen-site-data-icon-button.identity-box-button');
   assert.match(urlbarIconSelector, /\.urlbar-page-action/);
   assert.match(urlbarIconSelector, /\.identity-box-button/);
   assert.match(urlbarIconSelector, /\.urlbar-icon/);
+  assert.match(urlbarIconSelector, /#identity-box/);
+  assert.match(urlbarIconSelector, /#tracking-protection-icon-container/);
+  assert.match(urlbarIconSelector, /#zen-site-data-icon-button/);
+  assert.match(urlbarIconBlock, /fill-opacity:\s*1\s*!important/);
+  assert.match(urlbarIconBlock, /--toolbarbutton-icon-fill:\s*currentColor\s*!important/);
+  assert.match(urlbarIconBlock, /--urlbar-icon-fill-opacity:\s*1/);
+  assert.match(unscopedChromeIconSelector, /#nav-bar-customization-target > :not\(#urlbar-container\)/);
+  assert.match(unscopedChromeIconSelector, /#zen-copy-url-button[\s\S]*:is\(\.urlbar-icon,\s*image\)/);
+  assert.match(unscopedChromeIconBlock, /color:\s*var\(--zen-tab-header-foreground,\s*inherit\)\s*!important/);
+  assert.match(unscopedChromeIconBlock, /fill:\s*currentColor\s*!important/);
+  assert.match(zenSiteDataButtonBlock, /color:\s*var\(--zen-tab-header-foreground,\s*inherit\)\s*!important/);
+  assert.match(zenSiteDataButtonBlock, /--toolbarbutton-icon-fill:\s*currentColor\s*!important/);
   assert.match(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\) #zen-site-data-icon-button\[boosting\] image\s*\{[^}]*color:\s*var\(--zen-tab-header-foreground,\s*currentColor\)\s*!important/s);
   assert.match(css, /#urlbar:not\(\[zen-floating-urlbar="true"\]\) #zen-site-data-icon-button\[boosting\] image\s*\{[^}]*--toolbarbutton-icon-fill:\s*currentColor/s);
   assert.doesNotMatch(css, /#urlbar\[zen-floating-urlbar="true"\]\s+#urlbar-input/);

--- a/tests/native-theme.test.js
+++ b/tests/native-theme.test.js
@@ -363,6 +363,8 @@ test('hidden tab sidebar toolbar icons use the softer addressbar chrome foregrou
   assert.match(headerCss, /\.urlbar-icon/);
   assert.match(headerCss, /\.identity-box-button/);
   assert.match(headerCss, /\.urlbar-page-action/);
+  assert.match(headerCss, /#zen-site-data-icon-button/);
+  assert.match(headerCss, /#zen-site-data-icon-button\s+image/);
   assert.match(headerCss, /fill-opacity:\s*0\.6\s*!important/);
   assert.match(headerCss, /--urlbar-icon-fill-opacity:\s*0\.6/);
   const compactSelector = '&:has([zen-compact-mode="true"]):not(:has(#navigator-toolbox[tabs-hidden])) #zen-appcontent-navbar-wrapper';
@@ -392,6 +394,21 @@ test('adaptive chrome colors cover Zen moved sidebar toolbar and copy URL icons'
   assert.match(copyUrlIconBlock, /fill:\s*currentColor\s*!important/);
   assert.match(copyUrlIconBlock, /fill-opacity:\s*1\s*!important/);
   assert.match(copyUrlIconBlock, /--toolbarbutton-icon-fill:\s*currentColor\s*!important/);
+});
+
+test('window controls follow adaptive header colors in sidebar and addressbar placements', () => {
+  const css = readStyleWithImports();
+  const addressbarTrafficSelector = cssSelectorPrelude(css, '#zen-appcontent-navbar-wrapper .titlebar-buttonbox-container');
+  const sidebarTrafficSelector = cssSelectorPrelude(css, '#zen-sidebar-top-buttons .titlebar-buttonbox-container');
+
+  for (const selector of [addressbarTrafficSelector, sidebarTrafficSelector]) {
+    assert.match(selector, /\.titlebar-buttonbox-container/);
+  }
+
+  const trafficBlock = cssRuleBlock(css, '#zen-appcontent-navbar-wrapper .titlebar-buttonbox-container');
+  assert.match(trafficBlock, /color:\s*var\(--zen-tab-header-foreground,\s*inherit\)\s*!important/);
+  assert.match(trafficBlock, /--toolbox-textcolor:\s*var\(--zen-tab-header-foreground,\s*currentColor\)/);
+  assert.match(trafficBlock, /--zen-toolbar-element-bg:\s*color-mix\(in srgb,\s*currentColor\s*14%,\s*transparent\)\s*!important/);
 });
 
 test('hidden tab chrome styling lives in a focused imported stylesheet', () => {

--- a/theme.json
+++ b/theme.json
@@ -3,9 +3,9 @@
   "name": "Blended Addressbar",
   "description": "A page-aware addressbar that blends Zen chrome with the active website.",
   "author": "Kostiantyn Kugot",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "ai": "partial",
-  "updatedAt": "2026-06-19",
+  "updatedAt": "2026-08-09",
   "tags": [
     "addressbar",
     "urlbar",


### PR DESCRIPTION
## Summary
- Fixes #8 by applying the adaptive foreground and full icon opacity to the Zen browser moved sidebar toggle and copy-link icons.
- Covers the titlebar and nav-bar placements used by Only Sidebar and compact modes.
- Bumps the mod version to 1.4.1.

## Validation
- node --test tests/native-theme.test.js — 43 passed.
- Rebased on fetched origin/main; merged locally into master.