### PR TITLE
fix: restore single-click toolbar navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ This directory contains Blended Addressbar, a Zen Browser UI mod that overhauls 
 - Prefer extending existing CSS variables over hardcoding new duplicated values.
 - Avoid adding dependencies, bundlers, or generated assets.
 - Maintain compatibility with Zen chrome context APIs already used here (`gBrowser`, progress listeners, chrome DOM access).
+- For every user-visible fix or release, update `CHANGELOG.md`, bump the version in `theme.json` and `blended-bar.uc.js`, and keep matching marketplace metadata in `MARKETPLACE.md` synchronized.
 
 ## Editing Guidance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.2 - 2026-08-09
+
+- Added regression coverage for Home, Back, and Forward controls staying clickable inside the browser window-drag region.
+
 ## 1.4.1 - 2026-08-09
 
 - Fixed adaptive foreground and opacity for Zen Only Sidebar, compact-mode, site-properties, copy-link, and macOS window-control icons; non-boost site-properties now follow light/dark page headers while Zen Boost keeps its native contrast.

--- a/MARKETPLACE.md
+++ b/MARKETPLACE.md
@@ -3,7 +3,7 @@
 ## Ready
 
 - Name: `Blended Addressbar` (18 characters).
-- Version: `1.4.0`.
+- Version: `1.4.2`.
 - Description: `A page-aware addressbar that blends Zen chrome with the active website.` (71 characters).
 - Metadata: `theme.json`.
 - Preferences: `preferences.json`.
@@ -29,9 +29,9 @@
   "readme": "https://raw.githubusercontent.com/kkugot/blended-addressbar/main/README.md",
   "image": "https://raw.githubusercontent.com/kkugot/blended-addressbar/main/marketplace-preview.png",
   "author": "Kostiantyn Kugot",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "ai": "partial",
-  "updatedAt": "2026-06-19",
+  "updatedAt": "2026-08-09",
   "style": {
     "chrome": "style.css",
     "content": ""

--- a/blended-bar.uc.js
+++ b/blended-bar.uc.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           Blended Addressbar
 // @description    Adaptive header color for Zen URL bar
-// @version        1.4.0
+// @version        1.4.2
 // ==/UserScript==
 
 (() => {

--- a/tests/native-theme.test.js
+++ b/tests/native-theme.test.js
@@ -252,6 +252,16 @@ test('adaptive header background and foreground keep short confirmed transitions
   assert.doesNotMatch(css, /\.tabbrowser-tab[\s\S]{0,160}transition:/);
 });
 
+test('interactive navigation controls stay outside the browser window drag region', () => {
+  const css = readStyleWithImports();
+  const noDragRule = cssRuleBlock(
+    css,
+    '#nav-bar-customization-target > :not(#urlbar-container):not(#urlbar[zen-floating-urlbar="true"]):is(toolbarbutton, toolbaritem)'
+  );
+
+  assert.match(noDragRule, /-moz-window-dragging:\s*no-drag/);
+});
+
 test('navigation color refreshes avoid repeated loading poll work', () => {
   const script = read('blended-bar.uc.js');
 

--- a/theme.json
+++ b/theme.json
@@ -3,7 +3,7 @@
   "name": "Blended Addressbar",
   "description": "A page-aware addressbar that blends Zen chrome with the active website.",
   "author": "Kostiantyn Kugot",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "ai": "partial",
   "updatedAt": "2026-08-09",
   "tags": [


### PR DESCRIPTION
## Summary

- Keep Home, Back, Forward, bookmark, and panel controls outside the browser window-drag region.
- Add regression coverage for clickable navigation controls.
- Bump the mod to 1.4.2 and update release metadata and guidance.

Fixes #2
Fixes #9

## Validation

- `node --test tests/*.js` (46 passing)
- JavaScript syntax, JSON, and Git diff checks pass.
- Windows validation was not run because no Windows environment is available.
