### PR TITLE
fix: stabilize bookmark popup colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.4.4 - 2026-08-10
+
+- Fixed default bookmark favicon colors and removed background transitions from bookmark folder buttons.
+
+## 1.4.3 - 2026-08-09
+
+- Forced bookmark toolbar popups to use native menu colors and removed their opening color transition.
+
 ## 1.4.2 - 2026-08-09
 
 - Added regression coverage for Home, Back, and Forward controls staying clickable inside the browser window-drag region.

--- a/MARKETPLACE.md
+++ b/MARKETPLACE.md
@@ -3,7 +3,7 @@
 ## Ready
 
 - Name: `Blended Addressbar` (18 characters).
-- Version: `1.4.2`.
+- Version: `1.4.4`.
 - Description: `A page-aware addressbar that blends Zen chrome with the active website.` (71 characters).
 - Metadata: `theme.json`.
 - Preferences: `preferences.json`.
@@ -29,7 +29,7 @@
   "readme": "https://raw.githubusercontent.com/kkugot/blended-addressbar/main/README.md",
   "image": "https://raw.githubusercontent.com/kkugot/blended-addressbar/main/marketplace-preview.png",
   "author": "Kostiantyn Kugot",
-  "version": "1.4.2",
+  "version": "1.4.4",
   "ai": "partial",
   "updatedAt": "2026-08-09",
   "style": {

--- a/blended-bar.uc.js
+++ b/blended-bar.uc.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           Blended Addressbar
 // @description    Adaptive header color for Zen URL bar
-// @version        1.4.2
+// @version        1.4.4
 // ==/UserScript==
 
 (() => {

--- a/style.css
+++ b/style.css
@@ -49,6 +49,64 @@
         0 2px 8px rgba(0, 0, 0, 0.10);
 }
 
+/* Bookmark folder popups keep the native system menu palette. */
+menupopup[placespopup="true"] {
+    background: Menu !important;
+    background-color: Menu !important;
+    --panel-background: Menu !important;
+    --panel-color: MenuText !important;
+    --panel-background-color: Menu !important;
+    --panel-text-color: MenuText !important;
+    --background-color-canvas: Menu !important;
+    --menuitem-icon-fill: MenuText !important;
+    --panel-border-color: var(--blended-addressbar-bookmark-popup-border-color) !important;
+    --panel-border-radius: var(--blended-addressbar-bookmark-popup-radius) !important;
+    --arrowpanel-background: Menu !important;
+    --arrowpanel-color: MenuText !important;
+    --arrowpanel-border-color: var(--blended-addressbar-bookmark-popup-border-color) !important;
+    --arrowpanel-border-radius: var(--blended-addressbar-bookmark-popup-radius) !important;
+    color: MenuText !important;
+    fill: currentColor !important;
+    stroke: currentColor !important;
+    --toolbox-textcolor: MenuText;
+    --toolbarbutton-icon-fill: currentColor;
+    --toolbar-color: MenuText;
+    transition: none !important;
+}
+
+menupopup[placespopup="true"]::part(content) {
+    background: Menu !important;
+    background-color: Menu !important;
+    color: MenuText !important;
+    border-color: var(--blended-addressbar-bookmark-popup-border-color) !important;
+    border-radius: var(--blended-addressbar-bookmark-popup-radius) !important;
+    overflow: hidden !important;
+    transition: none !important;
+}
+
+menupopup[placespopup="true"] :is(menu, menuitem, .menu-iconic, .menuitem-iconic, .menu-iconic-text, .menuitem-iconic-text, .menu-text, .menuitem-text, .bookmark-item) {
+    color: MenuText !important;
+    fill: currentColor !important;
+    stroke: currentColor !important;
+    --toolbox-textcolor: MenuText;
+    --toolbarbutton-icon-fill: currentColor;
+    --toolbar-color: MenuText;
+}
+
+menupopup[placespopup="true"] .menu-icon {
+    color: MenuText !important;
+    fill: MenuText !important;
+    stroke: MenuText !important;
+    -moz-context-properties: fill, fill-opacity !important;
+}
+
+menupopup[placespopup="true"] :is(menu, menuitem, .bookmark-item):is([disabled], [disabled="true"]) {
+    color: GrayText !important;
+    fill: currentColor !important;
+    stroke: currentColor !important;
+    --toolbarbutton-icon-fill: currentColor;
+}
+
 /* URL bar */
 
 #navigator-toolbox[zen-sidebar-expanded="true"] {
@@ -147,6 +205,11 @@
             -moz-window-dragging: no-drag;
         }
 
+        #PersonalToolbar #PlacesToolbarItems > toolbarbutton.bookmark-item,
+        #PersonalToolbar #PlacesToolbarItems > toolbarbutton.bookmark-item > :is(.toolbarbutton-icon, .toolbarbutton-text, .toolbarbutton-badge-stack) {
+            transition: none !important;
+        }
+
         :is(
             #nav-bar-customization-target > :not(#urlbar-container):not(#urlbar[zen-floating-urlbar="true"]),
             #nav-bar-customization-target > :not(#urlbar-container):not(#urlbar[zen-floating-urlbar="true"]) :is(toolbarbutton, .toolbarbutton-1, .toolbarbutton-icon, .toolbarbutton-text, .urlbar-icon),
@@ -195,47 +258,6 @@
             fill: currentColor !important;
             stroke: currentColor !important;
             transition: color var(--blended-addressbar-color-transition), fill var(--blended-addressbar-color-transition), stroke var(--blended-addressbar-color-transition);
-            --toolbarbutton-icon-fill: currentColor;
-        }
-
-        #PersonalToolbar toolbarbutton.bookmark-item > menupopup.toolbar-menupopup[placespopup="true"] {
-            --panel-background: Menu !important;
-            --panel-color: MenuText !important;
-            --panel-border-color: var(--blended-addressbar-bookmark-popup-border-color) !important;
-            --panel-border-radius: var(--blended-addressbar-bookmark-popup-radius) !important;
-            --arrowpanel-background: Menu !important;
-            --arrowpanel-color: MenuText !important;
-            --arrowpanel-border-color: var(--blended-addressbar-bookmark-popup-border-color) !important;
-            --arrowpanel-border-radius: var(--blended-addressbar-bookmark-popup-radius) !important;
-            color: MenuText !important;
-            fill: currentColor !important;
-            stroke: currentColor !important;
-            --toolbox-textcolor: MenuText;
-            --toolbarbutton-icon-fill: currentColor;
-            --toolbar-color: MenuText;
-        }
-
-        #PersonalToolbar toolbarbutton.bookmark-item > menupopup.toolbar-menupopup[placespopup="true"]::part(content) {
-            background: Menu !important;
-            color: MenuText !important;
-            border-color: var(--blended-addressbar-bookmark-popup-border-color) !important;
-            border-radius: var(--blended-addressbar-bookmark-popup-radius) !important;
-            overflow: hidden !important;
-        }
-
-        #PersonalToolbar toolbarbutton.bookmark-item > menupopup.toolbar-menupopup[placespopup="true"] :is(menu, menuitem, .menu-iconic, .menuitem-iconic, .bookmark-item) {
-            color: MenuText !important;
-            fill: currentColor !important;
-            stroke: currentColor !important;
-            --toolbox-textcolor: MenuText;
-            --toolbarbutton-icon-fill: currentColor;
-            --toolbar-color: MenuText;
-        }
-
-        #PersonalToolbar toolbarbutton.bookmark-item > menupopup.toolbar-menupopup[placespopup="true"] :is(menu, menuitem, .bookmark-item):is([disabled], [disabled="true"]) {
-            color: GrayText !important;
-            fill: currentColor !important;
-            stroke: currentColor !important;
             --toolbarbutton-icon-fill: currentColor;
         }
 

--- a/tests/native-theme.test.js
+++ b/tests/native-theme.test.js
@@ -1114,26 +1114,42 @@ test('non-boost site properties icon follows adaptive header colors while boost 
   assert.doesNotMatch(nonBoostButtonBlock, /\[boosting\]/);
 });
 
-test('bookmark toolbar popups keep readable menu colors and compact corners', () => {
+test('bookmark toolbar popups use native colors and keep compact corners', () => {
   const css = read('style.css');
-  const popupSelector = '#PersonalToolbar toolbarbutton.bookmark-item > menupopup.toolbar-menupopup[placespopup="true"]';
+  const popupSelector = 'menupopup[placespopup="true"]';
   const popupBlock = cssRuleBlock(css, popupSelector);
   const popupContentBlock = cssRuleBlock(css, `${popupSelector}::part(content)`);
-  const popupItemBlock = cssRuleBlock(css, `${popupSelector} :is(menu, menuitem, .menu-iconic, .menuitem-iconic, .bookmark-item)`);
+  const popupItemBlock = cssRuleBlock(css, `${popupSelector} :is(menu, menuitem, .menu-iconic, .menuitem-iconic, .menu-iconic-text, .menuitem-iconic-text, .menu-text, .menuitem-text, .bookmark-item)`);
+  const popupIconBlock = cssRuleBlock(css, `${popupSelector} .menu-icon`);
   const disabledPopupItemBlock = cssRuleBlock(css, `${popupSelector} :is(menu, menuitem, .bookmark-item):is([disabled], [disabled="true"])`);
+  const folderButtonBlock = cssRuleBlock(css, '#PersonalToolbar #PlacesToolbarItems > toolbarbutton.bookmark-item');
 
   assert.match(css, /--blended-addressbar-bookmark-popup-radius:\s*8px/);
+  assert.match(css, /(?:^|\n)menupopup\[placespopup="true"\]\s*\{/);
+  assert.doesNotMatch(css, /#PersonalToolbar toolbarbutton\.bookmark-item\s*>\s*menupopup(?:\.toolbar-menupopup)?\[placespopup="true"\]/);
+  assert.match(popupBlock, /background:\s*Menu\s*!important/);
   assert.match(popupBlock, /--panel-background:\s*Menu\s*!important/);
   assert.match(popupBlock, /--panel-color:\s*MenuText\s*!important/);
+  assert.match(popupBlock, /--panel-background-color:\s*Menu\s*!important/);
+  assert.match(popupBlock, /--panel-text-color:\s*MenuText\s*!important/);
+  assert.match(popupBlock, /--background-color-canvas:\s*Menu\s*!important/);
+  assert.match(popupBlock, /--menuitem-icon-fill:\s*MenuText\s*!important/);
+  assert.match(popupBlock, /--arrowpanel-background:\s*Menu\s*!important/);
+  assert.match(popupBlock, /--arrowpanel-color:\s*MenuText\s*!important/);
   assert.match(popupBlock, /--panel-border-radius:\s*var\(--blended-addressbar-bookmark-popup-radius\)\s*!important/);
+  assert.match(popupBlock, /transition:\s*none\s*!important/);
   assert.match(popupContentBlock, /background:\s*Menu\s*!important/);
   assert.match(popupContentBlock, /color:\s*MenuText\s*!important/);
   assert.match(popupContentBlock, /border-radius:\s*var\(--blended-addressbar-bookmark-popup-radius\)\s*!important/);
   assert.match(popupContentBlock, /overflow:\s*hidden\s*!important/);
+  assert.match(popupContentBlock, /transition:\s*none\s*!important/);
   assert.match(popupItemBlock, /color:\s*MenuText\s*!important/);
+  assert.match(css, /menupopup\[placespopup="true"\][\s\S]*\.menu-iconic-text/);
   assert.match(popupItemBlock, /--toolbarbutton-icon-fill:\s*currentColor/);
+  assert.match(popupIconBlock, /fill:\s*MenuText\s*!important/);
   assert.match(disabledPopupItemBlock, /color:\s*GrayText\s*!important/);
-  assert.doesNotMatch(popupBlock, /var\(--zen-tab-header-foreground/);
+  assert.doesNotMatch(popupBlock, /var\(--zen-tab-header-(?:background|foreground)/);
+  assert.match(folderButtonBlock, /transition:\s*none\s*!important/);
 });
 
 test('addressbar and bookmarks separator can be collapsed to one visible line', () => {

--- a/theme.json
+++ b/theme.json
@@ -3,7 +3,7 @@
   "name": "Blended Addressbar",
   "description": "A page-aware addressbar that blends Zen chrome with the active website.",
   "author": "Kostiantyn Kugot",
-  "version": "1.4.2",
+  "version": "1.4.4",
   "ai": "partial",
   "updatedAt": "2026-08-09",
   "tags": [


### PR DESCRIPTION
Summary: force bookmark Places popups to native Menu/MenuText colors, align default favicon icons, and disable bookmark folder button transitions. Version bumped to 1.4.4 with changelog and marketplace metadata synchronized. Validation: node --test tests/native-theme.test.js (46/46) and git diff --check.