### PR TITLE
Release 1.5.0 with single-toolbar support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.5.0 - 2026-09-03
+
+- Added browser frame, window tint, split view, compact mode, fullscreen, and loading-bar support to Zen's single-toolbar Only Sidebar layout while keeping its sidebar addressbar native.
+- Fixed macOS traffic lights in Collapsed Sidebar mode with compact horizontal controls centered inside the narrow rail.
+- Added an unchecked `Remove browser frame rounding` setting that preserves the configured radius while active.
+
 ## 1.4.4 - 2026-08-10
 
 - Fixed default bookmark favicon colors and removed background transitions from bookmark folder buttons.

--- a/MARKETPLACE.md
+++ b/MARKETPLACE.md
@@ -3,7 +3,7 @@
 ## Ready
 
 - Name: `Blended Addressbar` (18 characters).
-- Version: `1.4.4`.
+- Version: `1.5.0`.
 - Description: `A page-aware addressbar that blends Zen chrome with the active website.` (71 characters).
 - Metadata: `theme.json`.
 - Preferences: `preferences.json`.
@@ -29,9 +29,9 @@
   "readme": "https://raw.githubusercontent.com/kkugot/blended-addressbar/main/README.md",
   "image": "https://raw.githubusercontent.com/kkugot/blended-addressbar/main/marketplace-preview.png",
   "author": "Kostiantyn Kugot",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "ai": "partial",
-  "updatedAt": "2026-08-09",
+  "updatedAt": "2026-09-03",
   "style": {
     "chrome": "style.css",
     "content": ""

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 An addressbar that belongs to the page.
 
-Blended Addressbar is a Zen Browser mod that reshapes the dual-toolbar addressbar into a page-aware browser frame with adaptive colors.
+Blended Addressbar is a Zen Browser mod that adds a compact, page-aware browser frame to Zen's dual-toolbar and Only Sidebar layouts. Dual-toolbar layouts also blend the addressbar with the active page.
 
 ![Blended Addressbar preview](marketplace-preview.png)
 
 ## Features
 
-- Adaptive addressbar background and foreground colors from active-page semantic colors.
+- Adaptive addressbar background and foreground colors from active-page semantic colors in dual-toolbar layouts.
 - Readability guardrails for adaptive foreground colors.
 - Browser window tinting that mixes the active site theme into Zen's existing browser theme instead of replacing it. The tint is optional and configurable by percentage.
 - Compact framed browser surface with configurable corner radius, frame gap, padding removal, and selectable shadow strength.
@@ -23,7 +23,7 @@ Blended Addressbar is distributed through [Sine](https://github.com/CosmoCreeper
 
 ## Compatibility
 
-This mod targets Zen Browser dual-toolbar layouts. Compact mode is supported, but visual validation is still recommended after Zen updates because browser chrome selectors can change.
+This mod targets Zen Browser dual-toolbar and Only Sidebar layouts. Only Sidebar keeps Zen's native sidebar addressbar while the frame, window tint, split view, compact mode, and loading bar remain supported. Visual validation is still recommended after Zen updates because browser chrome selectors can change.
 
 ## Preferences
 
@@ -33,6 +33,7 @@ The mod exposes its settings through `preferences.json`.
 - `uc.blended-addressbar.window-tint.strength`: tint strength as a percentage from `0` to `100`; defaults to `25`.
 - Page colors are always remembered in memory while browsing.
 - `uc.blended-addressbar.frame-radius`: outer browser frame corner radius as a CSS length, such as `8px` or `0`.
+- `uc.blended-addressbar.frame-radius.disabled`: remove browser frame rounding without changing the configured radius; disabled by default.
 - `uc.blended-addressbar.frame-gap`: spacing around the browser frame as a CSS length, such as `5px` or `0`.
 - `uc.blended-addressbar.frame-padding.disabled`: remove the browser frame padding around page content.
 - `uc.blended-addressbar.addressbar-bookmarks-separator.disabled`: remove the separator between the addressbar and visible bookmarks bar.

--- a/blended-bar.uc.js
+++ b/blended-bar.uc.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           Blended Addressbar
 // @description    Adaptive header color for Zen URL bar
-// @version        1.4.4
+// @version        1.5.0
 // ==/UserScript==
 
 (() => {
@@ -41,11 +41,13 @@
   const defaultLoadbarMode = 'glow';
   const addressbarPrefBranch = 'uc.blended-addressbar.';
   const frameRadiusPref = `${addressbarPrefBranch}frame-radius`;
+  const frameRadiusDisabledPref = `${addressbarPrefBranch}frame-radius.disabled`;
   const frameGapPref = `${addressbarPrefBranch}frame-gap`;
   const framePaddingDisabledPref = `${addressbarPrefBranch}frame-padding.disabled`;
   const frameShadowPref = `${addressbarPrefBranch}frame-shadow`;
   const framePrefNames = Object.freeze(new Set([
     frameRadiusPref,
+    frameRadiusDisabledPref,
     frameGapPref,
     framePaddingDisabledPref,
     frameShadowPref
@@ -1021,7 +1023,9 @@
   function applyFramePrefs() {
     const root = chromeDoc.documentElement;
     const rootStyle = root.style;
-    const radius = normalizeCssLength(readStringPref(frameRadiusPref, '14px'), '14px');
+    const radius = readBoolPref(frameRadiusDisabledPref, false)
+      ? '0px'
+      : normalizeCssLength(readStringPref(frameRadiusPref, '14px'), '14px');
     const gap = readBoolPref(framePaddingDisabledPref, false) ? '0px' : normalizeCssLength(readStringPref(frameGapPref, '5px'), '5px');
     const shadowPreset = normalizeFrameShadowPreset(readStringPref(frameShadowPref, 'standard'));
 

--- a/preferences.json
+++ b/preferences.json
@@ -11,6 +11,12 @@
     "defaultValue": "14px"
   },
   {
+    "property": "uc.blended-addressbar.frame-radius.disabled",
+    "label": "Remove browser frame rounding",
+    "type": "checkbox",
+    "defaultValue": false
+  },
+  {
     "property": "uc.blended-addressbar.frame-gap",
     "label": "Frame gap",
     "type": "string",

--- a/style.css
+++ b/style.css
@@ -113,7 +113,7 @@ menupopup[placespopup="true"] :is(menu, menuitem, .bookmark-item):is([disabled],
     padding-top: 2px !important;
 }
 
-/* Only in single toolbar mode */
+/* Dual-toolbar addressbar */
 :root:not([zen-single-toolbar="true"]) {
 
     /* Wrapper */
@@ -153,13 +153,6 @@ menupopup[placespopup="true"] :is(menu, menuitem, .bookmark-item):is([disabled],
             box-shadow: none !important;
         }
 
-        #tabbrowser-tabpanels > .browserSidebarContainer:not(.zen-glance-overlay) {
-            --blended-addressbar-split-radius-top-left: 0px;
-            --blended-addressbar-split-radius-top-right: 0px;
-            --blended-addressbar-split-radius-bottom-right: 0px;
-            --blended-addressbar-split-radius-bottom-left: 0px;
-            --zen-native-inner-radius: 0 0 0 0 !important;
-        }
     }
 
     &[chromehidden~="toolbar"],
@@ -170,10 +163,6 @@ menupopup[placespopup="true"] :is(menu, menuitem, .bookmark-item):is([disabled],
         }
     }
 
-    #tabbrowser-tabpanels,
-    #tabbrowser-tabbox {
-        overflow: hidden;
-    }
     /* The URL bar with bookmarks */
     #zen-appcontent-navbar-wrapper {
         background-color: var(--zen-tab-header-background, var(--zen-main-browser-background-toolbar));
@@ -397,45 +386,8 @@ menupopup[placespopup="true"] :is(menu, menuitem, .bookmark-item):is([disabled],
         
     }
     
-    /* Hide shadow and border - they are now in a parent element */
-    #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
-        :root:not([zen-no-padding="true"]) &:not(.zen-glance-overlay) {
-            --blended-addressbar-split-radius-top-left: 0px;
-            --blended-addressbar-split-radius-top-right: 0px;
-            --blended-addressbar-split-radius-bottom-right: 0px;
-            --blended-addressbar-split-radius-bottom-left: 0px;
-            --zen-native-inner-radius:
-                var(--blended-addressbar-split-radius-top-left)
-                var(--blended-addressbar-split-radius-top-right)
-                var(--blended-addressbar-split-radius-bottom-right)
-                var(--blended-addressbar-split-radius-bottom-left) !important;
-            --zen-big-shadow: none;
-        }
-    }
-
-    #tabbrowser-tabpanels > .browserSidebarContainer:not(.zen-glance-overlay) {
-        --zen-native-inner-radius:
-                var(--blended-addressbar-split-radius-top-left)
-                var(--blended-addressbar-split-radius-top-right)
-                var(--blended-addressbar-split-radius-bottom-right)
-                var(--blended-addressbar-split-radius-bottom-left) !important;
-    }
-
-    /* Glance  modification*/
-    .browserSidebarContainer.zen-glance-background.deck-selected {
-         transform: scale(1) !important;
-    }
-
-    .zen-glance-overlay .browserContainer {
-         height: 98% !important;
-    }
     .urlbar-background {
         --zen-toolbar-element-bg: transparent;
-    }
-
-    /* Sidebar */
-    #sidebar-box {
-        border-radius: 0 !important;
     }
 
     .titlebar-button.titlebar-close  {
@@ -444,15 +396,105 @@ menupopup[placespopup="true"] :is(menu, menuitem, .bookmark-item):is([disabled],
     }
 }
 
+/* Browser surface shared by both toolbar layouts. */
+#tabbrowser-tabpanels,
+#tabbrowser-tabbox {
+    overflow: hidden;
+}
+
+#tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    :root:not([zen-no-padding="true"]) &:not(.zen-glance-overlay) {
+        --blended-addressbar-split-radius-top-left: 0px;
+        --blended-addressbar-split-radius-top-right: 0px;
+        --blended-addressbar-split-radius-bottom-right: 0px;
+        --blended-addressbar-split-radius-bottom-left: 0px;
+        --zen-native-inner-radius:
+            var(--blended-addressbar-split-radius-top-left)
+            var(--blended-addressbar-split-radius-top-right)
+            var(--blended-addressbar-split-radius-bottom-right)
+            var(--blended-addressbar-split-radius-bottom-left) !important;
+        --zen-big-shadow: none;
+    }
+}
+
+#tabbrowser-tabpanels > .browserSidebarContainer:not(.zen-glance-overlay) {
+    --zen-native-inner-radius:
+        var(--blended-addressbar-split-radius-top-left)
+        var(--blended-addressbar-split-radius-top-right)
+        var(--blended-addressbar-split-radius-bottom-right)
+        var(--blended-addressbar-split-radius-bottom-left) !important;
+}
+
+.browserSidebarContainer.zen-glance-background.deck-selected {
+    transform: scale(1) !important;
+}
+
+.zen-glance-overlay .browserContainer {
+    height: 98% !important;
+}
+
+#sidebar-box {
+    border-radius: 0 !important;
+}
+
+:root:is([inDOMFullscreen="true"], [inFullscreen="true"], [macOSNativeFullscreen], [zen-no-padding="true"])
+    #tabbrowser-tabpanels > .browserSidebarContainer:not(.zen-glance-overlay) {
+    --blended-addressbar-split-radius-top-left: 0px;
+    --blended-addressbar-split-radius-top-right: 0px;
+    --blended-addressbar-split-radius-bottom-right: 0px;
+    --blended-addressbar-split-radius-bottom-left: 0px;
+    --zen-native-inner-radius: 0 0 0 0 !important;
+}
+
+/* Single-toolbar mode keeps Zen's sidebar addressbar native. */
+:root[zen-single-toolbar="true"] {
+    &:not([zen-has-bookmarks]) #zen-appcontent-navbar-wrapper:not([should-hide="true"]) {
+        min-height: var(--blended-addressbar-frame-gap) !important;
+        height: var(--blended-addressbar-frame-gap) !important;
+    }
+
+    #zen-tabbox-wrapper {
+        margin: 0 var(--blended-addressbar-frame-gap) var(--blended-addressbar-frame-gap) 0 !important;
+        background-color: var(--blended-addressbar-frame-background, var(--zen-main-browser-background));
+        box-shadow: var(--blended-addressbar-frame-shadow);
+        border-radius: var(--blended-addressbar-frame-radius);
+        overflow: hidden;
+        isolation: isolate;
+    }
+
+    @media -moz-pref("zen.tabs.vertical.right-side") {
+        #zen-tabbox-wrapper {
+            margin: 0 0 var(--blended-addressbar-frame-gap) var(--blended-addressbar-frame-gap) !important;
+        }
+    }
+
+    &:has([zen-compact-mode="true"]) #zen-tabbox-wrapper {
+        margin: 0 var(--blended-addressbar-frame-gap) var(--blended-addressbar-frame-gap) var(--blended-addressbar-frame-gap) !important;
+    }
+
+    &:is([inDOMFullscreen="true"], [inFullscreen="true"], [macOSNativeFullscreen], [zen-no-padding="true"]) {
+        #zen-appcontent-navbar-wrapper {
+            min-height: 0 !important;
+            height: 0 !important;
+        }
+
+        #zen-tabbox-wrapper {
+            margin: 0 !important;
+            border-radius: 0 !important;
+            box-shadow: none !important;
+        }
+    }
+}
+
 @media (-moz-platform: macos) {
     :root:not([zen-single-toolbar="true"]):not([zen-sidebar-expanded="true"]):not([zen-compact-mode="true"])
         #nav-bar > .titlebar-buttonbox-container {
         position: fixed;
         inset-inline-start: 0;
-        top: 4px;
+        top: 0;
         z-index: 10;
         width: var(--zen-toolbox-max-width, 60px) !important;
-        height: 60px;
+        height: 42px;
         margin: 0 !important;
         padding: 0 !important;
         justify-content: center;
@@ -462,11 +504,11 @@ menupopup[placespopup="true"] :is(menu, menuitem, .bookmark-item):is([disabled],
             appearance: none !important;
             -moz-default-appearance: none !important;
             display: flex;
-            flex-direction: column;
+            flex-direction: row;
             align-items: center;
             justify-content: center;
-            gap: 8px;
-            width: 22px;
+            gap: 6px;
+            width: 100%;
             height: 100%;
             margin: 0 !important;
 
@@ -474,11 +516,11 @@ menupopup[placespopup="true"] :is(menu, menuitem, .bookmark-item):is([disabled],
                 appearance: none !important;
                 -moz-default-appearance: none !important;
                 display: flex !important;
-                flex: 0 0 12px;
-                width: 12px;
-                min-width: 12px;
-                height: 12px;
-                min-height: 12px;
+                flex: 0 0 10px;
+                width: 10px;
+                min-width: 10px;
+                height: 10px;
+                min-height: 10px;
                 padding: 0 !important;
                 border: 0 !important;
                 border-radius: 50% !important;
@@ -504,11 +546,6 @@ menupopup[placespopup="true"] :is(menu, menuitem, .bookmark-item):is([disabled],
         }
     }
 
-    :root:not([zen-single-toolbar="true"]):not([zen-sidebar-expanded="true"]):not([zen-compact-mode="true"])
-        #navigator-toolbox {
-        padding-top: calc(var(--zen-element-separation) * 3) !important;
-    }
-
     :root:not([zen-single-toolbar="true"]):not([zen-sidebar-expanded="true"]):not([zen-compact-mode="true"]):not([sizemode="maximized"], [sizemode="fullscreen"])
         #nav-bar > .titlebar-buttonbox-container .titlebar-restore,
     :root:not([zen-single-toolbar="true"]):not([zen-sidebar-expanded="true"]):not([zen-compact-mode="true"]):is([sizemode="maximized"], [sizemode="fullscreen"])
@@ -524,10 +561,16 @@ menupopup[placespopup="true"] :is(menu, menuitem, .bookmark-item):is([disabled],
 
         :root:not([zen-single-toolbar="true"]):not([zen-sidebar-expanded="true"]):not([zen-compact-mode="true"])
             #nav-bar > .titlebar-buttonbox-container {
-            --zen-traffic-light-size: 6px !important;
-            background-size: 22px calc(100% / 3) !important;
-            background-position: 50% 50% !important;
-            background-repeat: repeat-y !important;
+            background-image: none !important;
+
+            > .titlebar-buttonbox {
+                opacity: 1 !important;
+            }
+
+            &:not([zen-has-hover="true"]) > .titlebar-buttonbox > .titlebar-button {
+                background-color: var(--zen-toolbar-element-bg) !important;
+                box-shadow: none;
+            }
         }
     }
 }

--- a/style.css
+++ b/style.css
@@ -445,10 +445,89 @@ menupopup[placespopup="true"] :is(menu, menuitem, .bookmark-item):is([disabled],
 }
 
 @media (-moz-platform: macos) {
+    :root:not([zen-single-toolbar="true"]):not([zen-sidebar-expanded="true"]):not([zen-compact-mode="true"])
+        #nav-bar > .titlebar-buttonbox-container {
+        position: fixed;
+        inset-inline-start: 0;
+        top: 4px;
+        z-index: 10;
+        width: var(--zen-toolbox-max-width, 60px) !important;
+        height: 60px;
+        margin: 0 !important;
+        padding: 0 !important;
+        justify-content: center;
+        overflow: visible;
+
+        > .titlebar-buttonbox {
+            appearance: none !important;
+            -moz-default-appearance: none !important;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            width: 22px;
+            height: 100%;
+            margin: 0 !important;
+
+            > .titlebar-button {
+                appearance: none !important;
+                -moz-default-appearance: none !important;
+                display: flex !important;
+                flex: 0 0 12px;
+                width: 12px;
+                min-width: 12px;
+                height: 12px;
+                min-height: 12px;
+                padding: 0 !important;
+                border: 0 !important;
+                border-radius: 50% !important;
+                background-image: none !important;
+                box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.18);
+                list-style-image: none !important;
+            }
+
+            > .titlebar-close {
+                order: 0;
+                background-color: #ff5f57 !important;
+            }
+
+            > .titlebar-min {
+                order: 1;
+                background-color: #febc2e !important;
+            }
+
+            > :is(.titlebar-max, .titlebar-restore) {
+                order: 2;
+                background-color: #28c840 !important;
+            }
+        }
+    }
+
+    :root:not([zen-single-toolbar="true"]):not([zen-sidebar-expanded="true"]):not([zen-compact-mode="true"])
+        #navigator-toolbox {
+        padding-top: calc(var(--zen-element-separation) * 3) !important;
+    }
+
+    :root:not([zen-single-toolbar="true"]):not([zen-sidebar-expanded="true"]):not([zen-compact-mode="true"]):not([sizemode="maximized"], [sizemode="fullscreen"])
+        #nav-bar > .titlebar-buttonbox-container .titlebar-restore,
+    :root:not([zen-single-toolbar="true"]):not([zen-sidebar-expanded="true"]):not([zen-compact-mode="true"]):is([sizemode="maximized"], [sizemode="fullscreen"])
+        #nav-bar > .titlebar-buttonbox-container .titlebar-max {
+        display: none !important;
+    }
+
     @media -moz-pref("zen.widget.mac.mono-window-controls") {
         :root:not([window-modal-open="true"]):not([zen-single-toolbar="true"]) .titlebar-buttonbox-container {
             color: var(--zen-tab-header-foreground, inherit) !important;
             --zen-toolbar-element-bg: color-mix(in srgb, currentColor 14%, transparent) !important;
+        }
+
+        :root:not([zen-single-toolbar="true"]):not([zen-sidebar-expanded="true"]):not([zen-compact-mode="true"])
+            #nav-bar > .titlebar-buttonbox-container {
+            --zen-traffic-light-size: 6px !important;
+            background-size: 22px calc(100% / 3) !important;
+            background-position: 50% 50% !important;
+            background-repeat: repeat-y !important;
         }
     }
 }

--- a/tests/native-theme.test.js
+++ b/tests/native-theme.test.js
@@ -425,6 +425,22 @@ test('window controls follow adaptive header colors in sidebar and addressbar pl
   assert.match(sidebarTrafficBlock, /--zen-toolbar-element-bg:\s*color-mix\(in srgb,\s*currentColor\s*14%,\s*transparent\)\s*!important/);
 });
 
+test('visible collapsed macOS sidebar centers standard vertical window controls above tabs', () => {
+  const css = read('style.css');
+  const collapsedControls = /:root:not\(\[zen-single-toolbar="true"\]\):not\(\[zen-sidebar-expanded="true"\]\):not\(\[zen-compact-mode="true"\]\)\s*#nav-bar > \.titlebar-buttonbox-container\s*\{[^}]*position:\s*fixed;[^}]*inset-inline-start:\s*0;[^}]*top:\s*4px;[^}]*z-index:\s*10;[^}]*width:\s*var\(--zen-toolbox-max-width,\s*60px\)\s*!important;[^}]*height:\s*60px;[^}]*overflow:\s*visible/s;
+
+  assert.match(css, collapsedControls);
+  assert.match(css, /> \.titlebar-buttonbox\s*\{[^}]*appearance:\s*none\s*!important;[^}]*flex-direction:\s*column;[^}]*gap:\s*8px;[^}]*height:\s*100%;[^}]*margin:\s*0\s*!important/s);
+  assert.match(css, /> \.titlebar-button\s*\{[^}]*appearance:\s*none\s*!important;[^}]*display:\s*flex\s*!important;[^}]*flex:\s*0 0 12px;[^}]*border-radius:\s*50%\s*!important/s);
+  assert.match(css, /> \.titlebar-close\s*\{[^}]*order:\s*0;[^}]*background-color:\s*#ff5f57\s*!important/s);
+  assert.match(css, /> \.titlebar-min\s*\{[^}]*order:\s*1;[^}]*background-color:\s*#febc2e\s*!important/s);
+  assert.match(css, /> :is\(\.titlebar-max,\s*\.titlebar-restore\)\s*\{[^}]*order:\s*2;[^}]*background-color:\s*#28c840\s*!important/s);
+  assert.match(css, /:not\(\[sizemode="maximized"\],\s*\[sizemode="fullscreen"\]\)[\s\S]*\.titlebar-restore,[\s\S]*:is\(\[sizemode="maximized"\],\s*\[sizemode="fullscreen"\]\)[\s\S]*\.titlebar-max\s*\{\s*display:\s*none\s*!important/s);
+  assert.match(css, /#navigator-toolbox\s*\{[^}]*padding-top:\s*calc\(var\(--zen-element-separation\) \* 3\)\s*!important/s);
+  assert.match(css, /@media -moz-pref\("zen\.widget\.mac\.mono-window-controls"\)[\s\S]*#nav-bar > \.titlebar-buttonbox-container\s*\{[^}]*--zen-traffic-light-size:\s*6px\s*!important;[^}]*background-size:\s*22px calc\(100% \/ 3\)\s*!important;[^}]*background-repeat:\s*repeat-y\s*!important/s);
+  assert.doesNotMatch(css, /:root\[zen-compact-mode="true"\][^{]*#nav-bar > \.titlebar-buttonbox-container[^{]*\{[^}]*flex-direction:\s*column/s);
+});
+
 test('hidden tab chrome styling lives in a focused imported stylesheet', () => {
   const css = read('style.css');
   const headerCss = read('styles/header-chrome.css');

--- a/tests/native-theme.test.js
+++ b/tests/native-theme.test.js
@@ -63,6 +63,21 @@ function countOccurrences(value, needle) {
   return value.split(needle).length - 1;
 }
 
+test('release metadata stays synchronized at version 1.5.0', () => {
+  const theme = JSON.parse(read('theme.json'));
+  const script = read('blended-bar.uc.js');
+  const marketplace = read('MARKETPLACE.md');
+  const changelog = read('CHANGELOG.md');
+
+  assert.equal(theme.version, '1.5.0');
+  assert.equal(theme.updatedAt, '2026-09-03');
+  assert.match(script, /\/\/ @version\s+1\.5\.0/);
+  assert.match(marketplace, /Version: `1\.5\.0`/);
+  assert.match(marketplace, /"version": "1\.5\.0"/);
+  assert.match(marketplace, /"updatedAt": "2026-09-03"/);
+  assert.match(changelog, /## 1\.5\.0 - 2026-09-03/);
+});
+
 test('browser window tint bridges page colors through native Zen window theme variables', () => {
   const script = read('blended-bar.uc.js');
   const css = read('style.css');
@@ -343,6 +358,45 @@ test('frame gap, remove-padding checkbox, and inner radius settings coexist', ()
   assert.match(prefs, /uc\.blended-addressbar\.frame-padding\.disabled/);
 });
 
+test('remove frame rounding overrides the effective radius without erasing its configured value', () => {
+  const script = read('blended-bar.uc.js');
+  const prefsJson = JSON.parse(read('preferences.json'));
+  const readme = read('README.md');
+  const preference = prefsJson.find((pref) => pref.property === 'uc.blended-addressbar.frame-radius.disabled');
+
+  assert.deepEqual(preference, {
+    property: 'uc.blended-addressbar.frame-radius.disabled',
+    label: 'Remove browser frame rounding',
+    type: 'checkbox',
+    defaultValue: false
+  });
+  assert.match(script, /const frameRadiusDisabledPref = `\$\{addressbarPrefBranch\}frame-radius\.disabled`/);
+  assert.match(script, /const framePrefNames = Object\.freeze\(new Set\(\[[\s\S]*frameRadiusDisabledPref/);
+  assert.match(script, /const radius = readBoolPref\(frameRadiusDisabledPref,\s*false\)\s*\?\s*'0px'\s*:\s*normalizeCssLength\(readStringPref\(frameRadiusPref,\s*'14px'\),\s*'14px'\)/);
+  assert.match(readme, /uc\.blended-addressbar\.frame-radius\.disabled`: remove browser frame rounding without changing the configured radius/);
+});
+
+test('single-toolbar mode frames page content while leaving the sidebar addressbar native', () => {
+  const css = read('style.css');
+  const readme = read('README.md');
+  const singleStart = css.indexOf('/* Single-toolbar mode keeps Zen\'s sidebar addressbar native. */');
+  const singleEnd = css.indexOf('\n@media (-moz-platform: macos)', singleStart);
+
+  assert.notEqual(singleStart, -1, 'missing single-toolbar frame styles');
+  assert.notEqual(singleEnd, -1, 'missing end of single-toolbar frame styles');
+  const singleCss = css.slice(singleStart, singleEnd);
+
+  assert.match(singleCss, /:root\[zen-single-toolbar="true"\]/);
+  assert.match(singleCss, /#zen-appcontent-navbar-wrapper:not\(\[should-hide="true"\]\)\s*\{[^}]*min-height:\s*var\(--blended-addressbar-frame-gap\)\s*!important[^}]*height:\s*var\(--blended-addressbar-frame-gap\)\s*!important/s);
+  assert.match(singleCss, /#zen-tabbox-wrapper\s*\{[^}]*background-color:\s*var\(--blended-addressbar-frame-background,\s*var\(--zen-main-browser-background\)\)[^}]*box-shadow:\s*var\(--blended-addressbar-frame-shadow\)[^}]*border-radius:\s*var\(--blended-addressbar-frame-radius\)[^}]*overflow:\s*hidden/s);
+  assert.match(singleCss, /@media -moz-pref\("zen\.tabs\.vertical\.right-side"\)[\s\S]*#zen-tabbox-wrapper\s*\{[^}]*margin:\s*0 0 var\(--blended-addressbar-frame-gap\) var\(--blended-addressbar-frame-gap\)\s*!important/s);
+  assert.match(singleCss, /&:has\(\[zen-compact-mode="true"\]\) #zen-tabbox-wrapper\s*\{[^}]*margin:\s*0 var\(--blended-addressbar-frame-gap\) var\(--blended-addressbar-frame-gap\) var\(--blended-addressbar-frame-gap\)\s*!important/s);
+  assert.match(singleCss, /&:is\(\[inDOMFullscreen="true"\],\s*\[inFullscreen="true"\],\s*\[macOSNativeFullscreen\],\s*\[zen-no-padding="true"\]\)[\s\S]*#zen-appcontent-navbar-wrapper\s*\{[^}]*min-height:\s*0\s*!important[^}]*height:\s*0\s*!important[\s\S]*#zen-tabbox-wrapper\s*\{[^}]*margin:\s*0\s*!important[^}]*border-radius:\s*0\s*!important[^}]*box-shadow:\s*none\s*!important/s);
+  assert.doesNotMatch(singleCss, /#urlbar/);
+  assert.doesNotMatch(singleCss, /--zen-tab-header-(?:background|foreground)/);
+  assert.match(readme, /Only Sidebar keeps Zen's native sidebar addressbar/);
+});
+
 test('DOM fullscreen removes the framed browser surface', () => {
   const css = read('style.css');
 
@@ -425,19 +479,19 @@ test('window controls follow adaptive header colors in sidebar and addressbar pl
   assert.match(sidebarTrafficBlock, /--zen-toolbar-element-bg:\s*color-mix\(in srgb,\s*currentColor\s*14%,\s*transparent\)\s*!important/);
 });
 
-test('visible collapsed macOS sidebar centers standard vertical window controls above tabs', () => {
+test('visible collapsed macOS sidebar fits compact horizontal window controls above tabs', () => {
   const css = read('style.css');
-  const collapsedControls = /:root:not\(\[zen-single-toolbar="true"\]\):not\(\[zen-sidebar-expanded="true"\]\):not\(\[zen-compact-mode="true"\]\)\s*#nav-bar > \.titlebar-buttonbox-container\s*\{[^}]*position:\s*fixed;[^}]*inset-inline-start:\s*0;[^}]*top:\s*4px;[^}]*z-index:\s*10;[^}]*width:\s*var\(--zen-toolbox-max-width,\s*60px\)\s*!important;[^}]*height:\s*60px;[^}]*overflow:\s*visible/s;
+  const collapsedControls = /:root:not\(\[zen-single-toolbar="true"\]\):not\(\[zen-sidebar-expanded="true"\]\):not\(\[zen-compact-mode="true"\]\)\s*#nav-bar > \.titlebar-buttonbox-container\s*\{[^}]*position:\s*fixed;[^}]*inset-inline-start:\s*0;[^}]*top:\s*0;[^}]*z-index:\s*10;[^}]*width:\s*var\(--zen-toolbox-max-width,\s*60px\)\s*!important;[^}]*height:\s*42px;[^}]*overflow:\s*visible/s;
 
   assert.match(css, collapsedControls);
-  assert.match(css, /> \.titlebar-buttonbox\s*\{[^}]*appearance:\s*none\s*!important;[^}]*flex-direction:\s*column;[^}]*gap:\s*8px;[^}]*height:\s*100%;[^}]*margin:\s*0\s*!important/s);
-  assert.match(css, /> \.titlebar-button\s*\{[^}]*appearance:\s*none\s*!important;[^}]*display:\s*flex\s*!important;[^}]*flex:\s*0 0 12px;[^}]*border-radius:\s*50%\s*!important/s);
+  assert.match(css, /> \.titlebar-buttonbox\s*\{[^}]*appearance:\s*none\s*!important;[^}]*flex-direction:\s*row;[^}]*gap:\s*6px;[^}]*width:\s*100%;[^}]*height:\s*100%;[^}]*margin:\s*0\s*!important/s);
+  assert.match(css, /> \.titlebar-button\s*\{[^}]*appearance:\s*none\s*!important;[^}]*display:\s*flex\s*!important;[^}]*flex:\s*0 0 10px;[^}]*width:\s*10px;[^}]*height:\s*10px;[^}]*border-radius:\s*50%\s*!important/s);
   assert.match(css, /> \.titlebar-close\s*\{[^}]*order:\s*0;[^}]*background-color:\s*#ff5f57\s*!important/s);
   assert.match(css, /> \.titlebar-min\s*\{[^}]*order:\s*1;[^}]*background-color:\s*#febc2e\s*!important/s);
   assert.match(css, /> :is\(\.titlebar-max,\s*\.titlebar-restore\)\s*\{[^}]*order:\s*2;[^}]*background-color:\s*#28c840\s*!important/s);
   assert.match(css, /:not\(\[sizemode="maximized"\],\s*\[sizemode="fullscreen"\]\)[\s\S]*\.titlebar-restore,[\s\S]*:is\(\[sizemode="maximized"\],\s*\[sizemode="fullscreen"\]\)[\s\S]*\.titlebar-max\s*\{\s*display:\s*none\s*!important/s);
-  assert.match(css, /#navigator-toolbox\s*\{[^}]*padding-top:\s*calc\(var\(--zen-element-separation\) \* 3\)\s*!important/s);
-  assert.match(css, /@media -moz-pref\("zen\.widget\.mac\.mono-window-controls"\)[\s\S]*#nav-bar > \.titlebar-buttonbox-container\s*\{[^}]*--zen-traffic-light-size:\s*6px\s*!important;[^}]*background-size:\s*22px calc\(100% \/ 3\)\s*!important;[^}]*background-repeat:\s*repeat-y\s*!important/s);
+  assert.doesNotMatch(css, /#navigator-toolbox\s*\{[^}]*padding-top:\s*calc\(var\(--zen-element-separation\) \* 3\)\s*!important/s);
+  assert.match(css, /@media -moz-pref\("zen\.widget\.mac\.mono-window-controls"\)[\s\S]*#nav-bar > \.titlebar-buttonbox-container\s*\{[^}]*background-image:\s*none\s*!important;[\s\S]*> \.titlebar-buttonbox\s*\{[^}]*opacity:\s*1\s*!important;[\s\S]*> \.titlebar-button\s*\{[^}]*background-color:\s*var\(--zen-toolbar-element-bg\)\s*!important/s);
   assert.doesNotMatch(css, /:root\[zen-compact-mode="true"\][^{]*#nav-bar > \.titlebar-buttonbox-container[^{]*\{[^}]*flex-direction:\s*column/s);
 });
 

--- a/theme.json
+++ b/theme.json
@@ -3,9 +3,9 @@
   "name": "Blended Addressbar",
   "description": "A page-aware addressbar that blends Zen chrome with the active website.",
   "author": "Kostiantyn Kugot",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "ai": "partial",
-  "updatedAt": "2026-08-09",
+  "updatedAt": "2026-09-03",
   "tags": [
     "addressbar",
     "urlbar",


### PR DESCRIPTION
## Summary
- support the Only Sidebar layout while keeping its addressbar native
- use compact horizontal macOS traffic lights in Collapsed Sidebar mode
- add an unchecked Remove browser frame rounding preference
- synchronize version 1.5.0 metadata and documentation

Closes #14

## Validation
- node --test tests/native-theme.test.js: 50 passed
- live Zen checks: Only Sidebar normal and compact, Collapsed Sidebar controls, settings toggle
- Impeccable layout detector: clean
- code review: ready to merge